### PR TITLE
feat : OAuth2.0 카카오 로그인 & JWT 인증 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
+    //OAuth2.0 Client
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+
     //OAuth2.0 Client
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
@@ -56,7 +59,6 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,11 @@ dependencies {
     //OAuth2.0 Client
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
+    //JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -51,14 +51,6 @@ dependencies {
 
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
-
-    //OAuth2.0 Client
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-
-    //JWT
-    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,14 @@ dependencies {
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
+    //OAuth2.0 Client
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    //JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -49,14 +49,6 @@ dependencies {
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
-    //OAuth2.0 Client
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-
-    //JWT
-    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,14 @@ dependencies {
 
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
+
+    //OAuth2.0 Client
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    //JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/prgrms/catchtable/common/Role.java
+++ b/src/main/java/com/prgrms/catchtable/common/Role.java
@@ -1,0 +1,14 @@
+package com.prgrms.catchtable.common;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+
+    MEMBER("ROLE_MEMBER"),
+    OWNER("ROLE_OWNER");
+
+    private final String role;
+}

--- a/src/main/java/com/prgrms/catchtable/jwt/config/JwtConfig.java
+++ b/src/main/java/com/prgrms/catchtable/jwt/config/JwtConfig.java
@@ -1,0 +1,16 @@
+package com.prgrms.catchtable.jwt.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@Data
+@ConfigurationProperties(prefix = "jwt")
+public class JwtConfig {
+
+    private String clientSecret;
+    private int expiryMinute;
+    private int expiryMinuteRefresh;
+
+}

--- a/src/main/java/com/prgrms/catchtable/jwt/domain/RefreshToken.java
+++ b/src/main/java/com/prgrms/catchtable/jwt/domain/RefreshToken.java
@@ -1,0 +1,35 @@
+package com.prgrms.catchtable.jwt.domain;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "token")
+    private String token;
+
+    @Column(name = "email")
+    private String email;
+
+    @Builder
+    public RefreshToken(String token, String email) {
+        this.token = token;
+        this.email = email;
+    }
+
+}

--- a/src/main/java/com/prgrms/catchtable/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/prgrms/catchtable/jwt/filter/JwtAuthenticationFilter.java
@@ -33,23 +33,23 @@ public class JwtAuthenticationFilter extends GenericFilter {
         String accessToken = ((HttpServletRequest) request).getHeader("AccessToken");
         String refreshToken = ((HttpServletRequest) request).getHeader("RefreshToken");
 
-        if(accessToken!=null){
+        if (accessToken != null) {
             //AccessToken 유효
-            if(jwtTokenProvider.validateToken(accessToken)){
+            if (jwtTokenProvider.validateToken(accessToken)) {
                 setAuthentication(accessToken);
             }
             //RefreshToken 유효
-            else{
-                if(jwtTokenProvider.validateToken(refreshToken)){
+            else {
+                if (jwtTokenProvider.validateToken(refreshToken)) {
                     RefreshToken refreshTokenEntity = refreshTokenService.getRefreshTokenByToken(
                         refreshToken);
                     String email = refreshTokenEntity.getEmail();
                     Token newToken = jwtTokenProvider.createToken(email);
 
-                    ((HttpServletResponse) response).setHeader("AccessToken", newToken.getAccessToken());
+                    ((HttpServletResponse) response).setHeader("AccessToken",
+                        newToken.getAccessToken());
                     setAuthentication(newToken.getAccessToken());
-                }
-                else{
+                } else {
                     throw new UsernameNotFoundException("Please Login again");
                 }
             }

--- a/src/main/java/com/prgrms/catchtable/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/prgrms/catchtable/jwt/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,63 @@
+package com.prgrms.catchtable.jwt.filter;
+
+import com.prgrms.catchtable.jwt.domain.RefreshToken;
+import com.prgrms.catchtable.jwt.provider.JwtTokenProvider;
+import com.prgrms.catchtable.jwt.service.RefreshTokenService;
+import com.prgrms.catchtable.jwt.token.Token;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.GenericFilter;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends GenericFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    private final RefreshTokenService refreshTokenService;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+        throws IOException, ServletException {
+
+        String accessToken = ((HttpServletRequest) request).getHeader("AccessToken");
+        String refreshToken = ((HttpServletRequest) request).getHeader("RefreshToken");
+
+        if(accessToken!=null){
+            //AccessToken 유효
+            if(jwtTokenProvider.validateToken(accessToken)){
+                setAuthentication(accessToken);
+            }
+            //RefreshToken 유효
+            else{
+                if(jwtTokenProvider.validateToken(refreshToken)){
+                    RefreshToken refreshTokenEntity = refreshTokenService.getRefreshTokenByToken(
+                        refreshToken);
+                    String email = refreshTokenEntity.getEmail();
+                    Token newToken = jwtTokenProvider.createToken(email);
+
+                    ((HttpServletResponse) response).setHeader("AccessToken", newToken.getAccessToken());
+                    setAuthentication(newToken.getAccessToken());
+                }
+                else{
+                    throw new UsernameNotFoundException("Please Login again");
+                }
+            }
+        }
+    }
+
+    private void setAuthentication(String accessToken) {
+        Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+}

--- a/src/main/java/com/prgrms/catchtable/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/prgrms/catchtable/jwt/filter/JwtAuthenticationFilter.java
@@ -54,6 +54,7 @@ public class JwtAuthenticationFilter extends GenericFilter {
                 }
             }
         }
+        chain.doFilter(request, response);
     }
 
     private void setAuthentication(String accessToken) {

--- a/src/main/java/com/prgrms/catchtable/jwt/provider/JwtTokenProvider.java
+++ b/src/main/java/com/prgrms/catchtable/jwt/provider/JwtTokenProvider.java
@@ -1,0 +1,54 @@
+package com.prgrms.catchtable.jwt.provider;
+
+
+import com.prgrms.catchtable.jwt.config.JwtConfig;
+import com.prgrms.catchtable.jwt.token.Token;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private final JwtConfig jwtConfig;
+
+    public Token createToken(String email) {
+
+        Claims claims = Jwts.claims().setSubject(email);
+        Date now = new Date();
+
+        String accessToken = createAccessToken(claims, now);
+        String refreshToken = createRefreshToken(claims, now);
+
+        return new Token(accessToken, refreshToken, email);
+
+    }
+
+    private String createAccessToken(Claims claims, Date now) {
+        long expiryMinute = jwtConfig.getExpiryMinute() * 1000L * 60;
+
+        return Jwts.builder()
+            .setClaims(claims)
+            .setIssuedAt(now)
+            .setExpiration(new Date(now.getTime() + expiryMinute))
+            .signWith(SignatureAlgorithm.HS256, jwtConfig.getClientSecret())
+            .compact();
+    }
+
+    private String createRefreshToken(Claims claims, Date now) {
+
+        long expiryMinuteRefresh = jwtConfig.getExpiryMinuteRefresh() * 1000L * 60;
+
+        return Jwts.builder()
+            .setClaims(claims)
+            .setIssuedAt(now)
+            .setExpiration(new Date(now.getTime() + expiryMinuteRefresh))
+            .signWith(SignatureAlgorithm.HS256, jwtConfig.getClientSecret())
+            .compact();
+    }
+
+}

--- a/src/main/java/com/prgrms/catchtable/jwt/provider/JwtTokenProvider.java
+++ b/src/main/java/com/prgrms/catchtable/jwt/provider/JwtTokenProvider.java
@@ -58,7 +58,7 @@ public class JwtTokenProvider {
     }
 
     public boolean validateToken(String token) {
-        try{
+        try {
             Claims claims = Jwts.parserBuilder()
                 .setSigningKey(jwtConfig.getClientSecret())
                 .build()
@@ -66,18 +66,19 @@ public class JwtTokenProvider {
                 .getBody();
 
             return claims.getExpiration().after(new Date());
-        } catch(JwtException je){
+        } catch (JwtException je) {
             return false;
         }
     }
 
-    public Authentication getAuthentication(String token){
+    public Authentication getAuthentication(String token) {
         String email = getEmail(token);
         UserDetails userDetails = jwtUserDetailsService.loadUserByUsername(email);
-        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+        return new UsernamePasswordAuthenticationToken(userDetails, "",
+            userDetails.getAuthorities());
     }
 
-    private String getEmail(String token){
+    private String getEmail(String token) {
         Claims claims = Jwts.parserBuilder()
             .setSigningKey(jwtConfig.getClientSecret())
             .build()

--- a/src/main/java/com/prgrms/catchtable/jwt/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/prgrms/catchtable/jwt/repository/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package com.prgrms.catchtable.jwt.repository;
+
+import com.prgrms.catchtable.jwt.domain.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+}

--- a/src/main/java/com/prgrms/catchtable/jwt/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/prgrms/catchtable/jwt/repository/RefreshTokenRepository.java
@@ -1,6 +1,7 @@
 package com.prgrms.catchtable.jwt.repository;
 
 import com.prgrms.catchtable.jwt.domain.RefreshToken;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
@@ -8,4 +9,6 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     boolean existsRefreshTokenByEmail(String email);
 
     void deleteRefreshTokenByEmail(String email);
+
+    Optional<RefreshToken> findRefreshTokenByToken(String token);
 }

--- a/src/main/java/com/prgrms/catchtable/jwt/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/prgrms/catchtable/jwt/repository/RefreshTokenRepository.java
@@ -4,4 +4,8 @@ import com.prgrms.catchtable.jwt.domain.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    boolean existsRefreshTokenByEmail(String email);
+
+    void deleteRefreshTokenByEmail(String email);
 }

--- a/src/main/java/com/prgrms/catchtable/jwt/service/JwtUserDetailsService.java
+++ b/src/main/java/com/prgrms/catchtable/jwt/service/JwtUserDetailsService.java
@@ -1,0 +1,21 @@
+package com.prgrms.catchtable.jwt.service;
+
+import com.prgrms.catchtable.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JwtUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        return memberRepository.findMemberByEmail(email)
+            .orElseThrow(() -> new UsernameNotFoundException("Not Found Member"));
+    }
+}

--- a/src/main/java/com/prgrms/catchtable/jwt/service/RefreshTokenService.java
+++ b/src/main/java/com/prgrms/catchtable/jwt/service/RefreshTokenService.java
@@ -1,0 +1,32 @@
+package com.prgrms.catchtable.jwt.service;
+
+import com.prgrms.catchtable.jwt.domain.RefreshToken;
+import com.prgrms.catchtable.jwt.repository.RefreshTokenRepository;
+import com.prgrms.catchtable.jwt.token.Token;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Transactional
+    public void saveRefreshToken(Token totalToken){
+        String email = totalToken.getEmail();
+
+        if(refreshTokenRepository.existsRefreshTokenByEmail(email)){
+            refreshTokenRepository.deleteRefreshTokenByEmail(email);
+        }
+
+        RefreshToken newRefreshToken = RefreshToken.builder()
+            .token(totalToken.getRefreshToken())
+            .email(email)
+            .build();
+
+        refreshTokenRepository.save(newRefreshToken);
+    }
+
+}

--- a/src/main/java/com/prgrms/catchtable/jwt/service/RefreshTokenService.java
+++ b/src/main/java/com/prgrms/catchtable/jwt/service/RefreshTokenService.java
@@ -4,6 +4,7 @@ import com.prgrms.catchtable.jwt.domain.RefreshToken;
 import com.prgrms.catchtable.jwt.repository.RefreshTokenRepository;
 import com.prgrms.catchtable.jwt.token.Token;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,4 +30,9 @@ public class RefreshTokenService {
         refreshTokenRepository.save(newRefreshToken);
     }
 
+    @Transactional(readOnly = true)
+    public RefreshToken getRefreshTokenByToken(String refreshToken){
+        return refreshTokenRepository.findRefreshTokenByToken(refreshToken)
+            .orElseThrow(() -> new UsernameNotFoundException("Not Found RefreshToken"));
+    }
 }

--- a/src/main/java/com/prgrms/catchtable/jwt/service/RefreshTokenService.java
+++ b/src/main/java/com/prgrms/catchtable/jwt/service/RefreshTokenService.java
@@ -15,10 +15,10 @@ public class RefreshTokenService {
     private final RefreshTokenRepository refreshTokenRepository;
 
     @Transactional
-    public void saveRefreshToken(Token totalToken){
+    public void saveRefreshToken(Token totalToken) {
         String email = totalToken.getEmail();
 
-        if(refreshTokenRepository.existsRefreshTokenByEmail(email)){
+        if (refreshTokenRepository.existsRefreshTokenByEmail(email)) {
             refreshTokenRepository.deleteRefreshTokenByEmail(email);
         }
 
@@ -31,7 +31,7 @@ public class RefreshTokenService {
     }
 
     @Transactional(readOnly = true)
-    public RefreshToken getRefreshTokenByToken(String refreshToken){
+    public RefreshToken getRefreshTokenByToken(String refreshToken) {
         return refreshTokenRepository.findRefreshTokenByToken(refreshToken)
             .orElseThrow(() -> new UsernameNotFoundException("Not Found RefreshToken"));
     }

--- a/src/main/java/com/prgrms/catchtable/jwt/token/Token.java
+++ b/src/main/java/com/prgrms/catchtable/jwt/token/Token.java
@@ -1,0 +1,15 @@
+package com.prgrms.catchtable.jwt.token;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class Token {
+
+    private String accessToken;
+
+    private String refreshToken;
+
+    private String email;
+}

--- a/src/main/java/com/prgrms/catchtable/member/domain/Member.java
+++ b/src/main/java/com/prgrms/catchtable/member/domain/Member.java
@@ -28,6 +28,9 @@ public class Member extends BaseEntity {
     @Column(name = "member_name")
     private String name;
 
+    @Column(name = "email")
+    private String email;
+
     @Column(name = "phone_number")
     private String phoneNumber;
 
@@ -42,12 +45,12 @@ public class Member extends BaseEntity {
     private boolean notification_activated;
 
     @Builder
-    public Member(String name, String phoneNumber, Gender gender, LocalDate dateBirth,
-        boolean notification_activated) {
+    public Member(String name, String email, String phoneNumber, Gender gender, LocalDate dateBirth) {
         this.name = name;
+        this.email = email;
         this.phoneNumber = phoneNumber;
         this.gender = gender;
         this.dateBirth = dateBirth;
-        this.notification_activated = notification_activated;
+        this.notification_activated = true;
     }
 }

--- a/src/main/java/com/prgrms/catchtable/member/domain/Member.java
+++ b/src/main/java/com/prgrms/catchtable/member/domain/Member.java
@@ -55,7 +55,8 @@ public class Member extends BaseEntity implements UserDetails {
     private boolean notification_activated;
 
     @Builder
-    public Member(String name, String email, String phoneNumber, Gender gender, LocalDate dateBirth) {
+    public Member(String name, String email, String phoneNumber, Gender gender,
+        LocalDate dateBirth) {
         this.name = name;
         this.email = email;
         this.phoneNumber = phoneNumber;

--- a/src/main/java/com/prgrms/catchtable/member/domain/Member.java
+++ b/src/main/java/com/prgrms/catchtable/member/domain/Member.java
@@ -5,20 +5,26 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 import com.prgrms.catchtable.common.BaseEntity;
+import com.prgrms.catchtable.common.Role;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import java.time.LocalDate;
+import java.util.Collection;
+import java.util.Collections;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 @Entity
-public class Member extends BaseEntity {
+public class Member extends BaseEntity implements UserDetails {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
@@ -38,6 +44,10 @@ public class Member extends BaseEntity {
     @Enumerated(STRING)
     private Gender gender;
 
+    @Column(name = "role")
+    @Enumerated(STRING)
+    private Role role;
+
     @Column(name = "date_birth")
     private LocalDate dateBirth;
 
@@ -52,5 +62,41 @@ public class Member extends BaseEntity {
         this.gender = gender;
         this.dateBirth = dateBirth;
         this.notification_activated = true;
+        this.role = Role.MEMBER;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(new SimpleGrantedAuthority(role.getRole()));
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
     }
 }

--- a/src/main/java/com/prgrms/catchtable/member/dto/MemberMapper.java
+++ b/src/main/java/com/prgrms/catchtable/member/dto/MemberMapper.java
@@ -1,0 +1,27 @@
+package com.prgrms.catchtable.member.dto;
+
+import com.prgrms.catchtable.member.domain.Gender;
+import com.prgrms.catchtable.member.domain.Member;
+import com.prgrms.catchtable.security.dto.OAuthAttribute;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+public class MemberMapper {
+
+    public static Member changeOAuth(OAuthAttribute attributes) {
+
+        String birthString = attributes.getBirthYear() + attributes.getBirthDay();
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+        LocalDate birthDay = LocalDate.parse(birthString, dateTimeFormatter);
+        System.out.println(birthDay);
+
+        return Member.builder()
+            .name(attributes.getName())
+            .email(attributes.getEmail())
+            .phoneNumber(attributes.getPhoneNumber())
+            .gender(attributes.getGender().equals("male") ? Gender.MALE : Gender.FEMALE)
+            .dateBirth(birthDay)
+            .build();
+    }
+
+}

--- a/src/main/java/com/prgrms/catchtable/member/repository/MemberRepository.java
+++ b/src/main/java/com/prgrms/catchtable/member/repository/MemberRepository.java
@@ -1,8 +1,11 @@
 package com.prgrms.catchtable.member.repository;
 
 import com.prgrms.catchtable.member.domain.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findMemberByEmail(String email);
 
 }

--- a/src/main/java/com/prgrms/catchtable/member/service/MemberService.java
+++ b/src/main/java/com/prgrms/catchtable/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.prgrms.catchtable.member.service;
 
 import com.prgrms.catchtable.jwt.provider.JwtTokenProvider;
+import com.prgrms.catchtable.jwt.service.RefreshTokenService;
 import com.prgrms.catchtable.jwt.token.Token;
 import com.prgrms.catchtable.member.domain.Member;
 import com.prgrms.catchtable.member.dto.MemberMapper;
@@ -19,6 +20,8 @@ public class MemberService {
 
     private final JwtTokenProvider jwtTokenProvider;
 
+    private final RefreshTokenService refreshTokenService;
+
     @Transactional
     public Token oauthLogin(OAuthAttribute attributes) {
         String email = attributes.getEmail();
@@ -29,6 +32,12 @@ public class MemberService {
             memberRepository.save(entity);
         }
 
-        return jwtTokenProvider.createToken(email);
+        return createTotalToken(email);
+    }
+
+    private Token createTotalToken(String email){
+        Token totalToken = jwtTokenProvider.createToken(email);
+        refreshTokenService.saveRefreshToken(totalToken);
+        return totalToken;
     }
 }

--- a/src/main/java/com/prgrms/catchtable/member/service/MemberService.java
+++ b/src/main/java/com/prgrms/catchtable/member/service/MemberService.java
@@ -1,5 +1,7 @@
 package com.prgrms.catchtable.member.service;
 
+import com.prgrms.catchtable.jwt.provider.JwtTokenProvider;
+import com.prgrms.catchtable.jwt.token.Token;
 import com.prgrms.catchtable.member.domain.Member;
 import com.prgrms.catchtable.member.dto.MemberMapper;
 import com.prgrms.catchtable.member.repository.MemberRepository;
@@ -15,8 +17,10 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
 
+    private final JwtTokenProvider jwtTokenProvider;
+
     @Transactional
-    public void oauthLogin(OAuthAttribute attributes) {
+    public Token oauthLogin(OAuthAttribute attributes) {
         String email = attributes.getEmail();
         Optional<Member> optionalMember = memberRepository.findMemberByEmail(email);
 
@@ -25,7 +29,6 @@ public class MemberService {
             memberRepository.save(entity);
         }
 
-        //JWT 토큰 생성 & 반환
+        return jwtTokenProvider.createToken(email);
     }
-
 }

--- a/src/main/java/com/prgrms/catchtable/member/service/MemberService.java
+++ b/src/main/java/com/prgrms/catchtable/member/service/MemberService.java
@@ -1,0 +1,31 @@
+package com.prgrms.catchtable.member.service;
+
+import com.prgrms.catchtable.member.domain.Member;
+import com.prgrms.catchtable.member.dto.MemberMapper;
+import com.prgrms.catchtable.member.repository.MemberRepository;
+import com.prgrms.catchtable.security.dto.OAuthAttribute;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void oauthLogin(OAuthAttribute attributes) {
+        String email = attributes.getEmail();
+        Optional<Member> optionalMember = memberRepository.findMemberByEmail(email);
+
+        if (optionalMember.isEmpty()) {
+            Member entity = MemberMapper.changeOAuth(attributes);
+            memberRepository.save(entity);
+        }
+
+        //JWT 토큰 생성 & 반환
+    }
+
+}

--- a/src/main/java/com/prgrms/catchtable/member/service/MemberService.java
+++ b/src/main/java/com/prgrms/catchtable/member/service/MemberService.java
@@ -35,7 +35,7 @@ public class MemberService {
         return createTotalToken(email);
     }
 
-    private Token createTotalToken(String email){
+    private Token createTotalToken(String email) {
         Token totalToken = jwtTokenProvider.createToken(email);
         refreshTokenService.saveRefreshToken(totalToken);
         return totalToken;

--- a/src/main/java/com/prgrms/catchtable/security/config/SecurityConfig.java
+++ b/src/main/java/com/prgrms/catchtable/security/config/SecurityConfig.java
@@ -1,0 +1,37 @@
+package com.prgrms.catchtable.security.config;
+
+import com.prgrms.catchtable.security.service.CustomOAuth2SuccessHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final CustomOAuth2SuccessHandler successHandler;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+            .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(
+                SessionCreationPolicy.STATELESS))
+            .formLogin(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests(authorization -> authorization
+                .requestMatchers(new AntPathRequestMatcher("/**")).permitAll()
+            )
+            .oauth2Login(oauth2Login -> oauth2Login.successHandler(successHandler));
+
+        return http.build();
+    }
+
+}

--- a/src/main/java/com/prgrms/catchtable/security/config/SecurityConfig.java
+++ b/src/main/java/com/prgrms/catchtable/security/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.prgrms.catchtable.security.config;
 
+import com.prgrms.catchtable.jwt.filter.JwtAuthenticationFilter;
 import com.prgrms.catchtable.security.service.CustomOAuth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -7,6 +8,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.stereotype.Component;
@@ -17,6 +19,8 @@ import org.springframework.stereotype.Component;
 public class SecurityConfig {
 
     private final CustomOAuth2SuccessHandler successHandler;
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -30,6 +34,8 @@ public class SecurityConfig {
                 .requestMatchers(new AntPathRequestMatcher("/**")).permitAll()
             )
             .oauth2Login(oauth2Login -> oauth2Login.successHandler(successHandler));
+
+        http.addFilterBefore(jwtAuthenticationFilter, OAuth2AuthorizationRequestRedirectFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/prgrms/catchtable/security/config/SecurityConfig.java
+++ b/src/main/java/com/prgrms/catchtable/security/config/SecurityConfig.java
@@ -35,7 +35,8 @@ public class SecurityConfig {
             )
             .oauth2Login(oauth2Login -> oauth2Login.successHandler(successHandler));
 
-        http.addFilterBefore(jwtAuthenticationFilter, OAuth2AuthorizationRequestRedirectFilter.class);
+        http.addFilterBefore(jwtAuthenticationFilter,
+            OAuth2AuthorizationRequestRedirectFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/prgrms/catchtable/security/dto/OAuthAttribute.java
+++ b/src/main/java/com/prgrms/catchtable/security/dto/OAuthAttribute.java
@@ -1,0 +1,65 @@
+package com.prgrms.catchtable.security.dto;
+
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@Getter
+public class OAuthAttribute {
+
+    String name;
+
+    String email;
+
+    String phoneNumber;
+
+    String birthYear;
+
+    String birthDay;
+
+    String gender;
+
+    @Builder
+    public OAuthAttribute(String name, String email, String phoneNumber, String birthYear,
+        String birthDay, String gender) {
+        this.name = name;
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+        this.birthYear = birthYear;
+        this.birthDay = birthDay;
+        this.gender = gender;
+    }
+
+    public static OAuthAttribute of(OAuth2User oAuth2User, String provider) {
+
+        OAuthAttribute oAuthAttribute;
+
+        if (provider.equals("kakao")) {
+            Map<String, Object> userAttributes = oAuth2User.getAttributes();
+            Map<String, Object> kakaoAccount = (Map<String, Object>) userAttributes.get(
+                "kakao_account");
+            Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+
+            String nickName = (String) profile.get("nickname");
+            String email = (String) kakaoAccount.get("email");
+            String phoneNumber = (String) kakaoAccount.get("phone_number");
+            String birthYear = (String) kakaoAccount.get("birthyear");
+            String birthDay = (String) kakaoAccount.get("birthday");
+            String gender = (String) kakaoAccount.get("gender");
+
+            oAuthAttribute = OAuthAttribute.builder()
+                .name(nickName)
+                .email(email)
+                .phoneNumber(phoneNumber)
+                .birthYear(birthYear)
+                .birthDay(birthDay)
+                .gender(gender)
+                .build();
+        } else {
+            oAuthAttribute = null;
+        }
+
+        return oAuthAttribute;
+    }
+}

--- a/src/main/java/com/prgrms/catchtable/security/dto/OAuthAttribute.java
+++ b/src/main/java/com/prgrms/catchtable/security/dto/OAuthAttribute.java
@@ -8,17 +8,17 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 @Getter
 public class OAuthAttribute {
 
-    String name;
+    private final String name;
 
-    String email;
+    private final String email;
 
-    String phoneNumber;
+    private final String phoneNumber;
 
-    String birthYear;
+    private final String birthYear;
 
-    String birthDay;
+    private final String birthDay;
 
-    String gender;
+    private final String gender;
 
     @Builder
     public OAuthAttribute(String name, String email, String phoneNumber, String birthYear,

--- a/src/main/java/com/prgrms/catchtable/security/service/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/prgrms/catchtable/security/service/CustomOAuth2SuccessHandler.java
@@ -1,0 +1,38 @@
+package com.prgrms.catchtable.security.service;
+
+import com.prgrms.catchtable.member.service.MemberService;
+import com.prgrms.catchtable.security.dto.OAuthAttribute;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CustomOAuth2SuccessHandler extends SavedRequestAwareAuthenticationSuccessHandler {
+
+    private final MemberService memberService;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+        Authentication authentication) throws IOException {
+
+        if (authentication instanceof OAuth2AuthenticationToken) {
+            OAuth2User oauth2User = ((OAuth2AuthenticationToken) authentication).getPrincipal();
+            String provider = ((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId();
+
+            OAuthAttribute oAuthAttribute = OAuthAttribute.of(oauth2User, provider);
+
+            //JWT 토큰 함께 발급
+            memberService.oauthLogin(oAuthAttribute);
+
+            //JWT 토큰을 Json으로 전달
+
+        }
+    }
+}

--- a/src/main/java/com/prgrms/catchtable/security/service/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/prgrms/catchtable/security/service/CustomOAuth2SuccessHandler.java
@@ -1,5 +1,8 @@
 package com.prgrms.catchtable.security.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.prgrms.catchtable.jwt.token.Token;
 import com.prgrms.catchtable.member.service.MemberService;
 import com.prgrms.catchtable.security.dto.OAuthAttribute;
 import jakarta.servlet.http.HttpServletRequest;
@@ -28,11 +31,22 @@ public class CustomOAuth2SuccessHandler extends SavedRequestAwareAuthenticationS
 
             OAuthAttribute oAuthAttribute = OAuthAttribute.of(oauth2User, provider);
 
-            //JWT 토큰 함께 발급
-            memberService.oauthLogin(oAuthAttribute);
+            Token token = memberService.oauthLogin(oAuthAttribute);
 
-            //JWT 토큰을 Json으로 전달
-
+            sendTokenJson(response, tokenToJson(token));
         }
     }
+
+    public String tokenToJson(Token token) throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        return objectMapper.writeValueAsString(token);
+    }
+
+    private void sendTokenJson(HttpServletResponse response, String tokenJson) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setContentLength(tokenJson.getBytes().length);
+        response.getWriter().write(tokenJson);
+    }
+
+
 }


### PR DESCRIPTION
closed #8 

### ⛏ 작업 상세 내용

- 기능 구현을 위한 Member 필드 수정 (email, role) 
- OAuth로그인 완료 후, AcessToken과 RefreshToken을 Json으로 응답
- RefreshToken 서버 저장을 위해 별도의 테이블 생성
- 설정 파일(yaml) 변경 참고

### 📝 작업 요약

- OAuth2.0 카카오 로그인
- JWT 인증 구현

### **☑️** 중점적으로 리뷰 할 부분

- 패키지 구조
- 네이밍
- 인증 방식 등
- 테스트는 별도의 issue로 생성 예정
