### PR TITLE
feat : 예약 최종 등록 로직 구현

### DIFF
--- a/src/main/java/com/prgrms/catchtable/common/exception/ErrorCode.java
+++ b/src/main/java/com/prgrms/catchtable/common/exception/ErrorCode.java
@@ -2,7 +2,6 @@ package com.prgrms.catchtable.common.exception;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/com/prgrms/catchtable/common/exception/ErrorResponse.java
+++ b/src/main/java/com/prgrms/catchtable/common/exception/ErrorResponse.java
@@ -4,15 +4,16 @@ import lombok.Getter;
 
 @Getter
 public class ErrorResponse {
+
     private final String code;
     private final String message;
 
-    public ErrorResponse(ErrorCode errorCode){
+    public ErrorResponse(ErrorCode errorCode) {
         this.code = errorCode.name();
         this.message = errorCode.getMessage();
     }
 
-    public ErrorResponse(String message){
+    public ErrorResponse(String message) {
         this.code = "BAD_REQUEST";
         this.message = message;
     }

--- a/src/main/java/com/prgrms/catchtable/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/prgrms/catchtable/common/exception/GlobalExceptionHandler.java
@@ -10,8 +10,10 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
     @ExceptionHandler
-    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(final MethodArgumentNotValidException exception) {
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+        final MethodArgumentNotValidException exception) {
         StringBuilder sb = new StringBuilder();
         for (FieldError fieldError : exception.getBindingResult().getFieldErrors()) {
             sb.append(fieldError.getDefaultMessage());
@@ -23,14 +25,16 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(NotFoundCustomException.class)
-    protected ResponseEntity<ErrorResponse> handleNotFoundException(final NotFoundCustomException exception) {
+    protected ResponseEntity<ErrorResponse> handleNotFoundException(
+        final NotFoundCustomException exception) {
         return ResponseEntity
             .badRequest()
             .body(new ErrorResponse(exception.getErrorCode()));
     }
 
     @ExceptionHandler(BadRequestCustomException.class)
-    protected ResponseEntity<ErrorResponse> handleBadRequestException(final BadRequestCustomException exception){
+    protected ResponseEntity<ErrorResponse> handleBadRequestException(
+        final BadRequestCustomException exception) {
         return ResponseEntity
             .badRequest()
             .body(new ErrorResponse(exception.getErrorCode()));

--- a/src/main/java/com/prgrms/catchtable/facade/ReservationFacade.java
+++ b/src/main/java/com/prgrms/catchtable/facade/ReservationFacade.java
@@ -1,8 +1,9 @@
 package com.prgrms.catchtable.facade;
 
+import static com.prgrms.catchtable.reservation.dto.mapper.ReservationMapper.toCreateReservationResponse;
+
 import com.prgrms.catchtable.reservation.domain.Reservation;
 import com.prgrms.catchtable.reservation.domain.ReservationTime;
-import com.prgrms.catchtable.reservation.dto.mapper.ReservationMapper;
 import com.prgrms.catchtable.reservation.dto.request.CreateReservationRequest;
 import com.prgrms.catchtable.reservation.dto.response.CreateReservationResponse;
 import com.prgrms.catchtable.reservation.service.ReservationAsync;
@@ -36,7 +37,7 @@ public class ReservationFacade {
 
     public CreateReservationResponse registerReservation(CreateReservationRequest request) {
         Reservation reservation = reservationService.validateReservationAndSaveIsEmpty(request);
-        return ReservationMapper.toCreateReservationResponse(reservation);
+        return toCreateReservationResponse(reservation);
     }
 
 }

--- a/src/main/java/com/prgrms/catchtable/facade/ReservationFacade.java
+++ b/src/main/java/com/prgrms/catchtable/facade/ReservationFacade.java
@@ -1,6 +1,8 @@
 package com.prgrms.catchtable.facade;
 
+import com.prgrms.catchtable.reservation.domain.Reservation;
 import com.prgrms.catchtable.reservation.domain.ReservationTime;
+import com.prgrms.catchtable.reservation.dto.mapper.ReservationMapper;
 import com.prgrms.catchtable.reservation.dto.request.CreateReservationRequest;
 import com.prgrms.catchtable.reservation.dto.response.CreateReservationResponse;
 import com.prgrms.catchtable.reservation.service.ReservationAsync;
@@ -30,6 +32,11 @@ public class ReservationFacade {
             .date(reservationTime.getTime())
             .peopleCount(request.peopleCount())
             .build();
+    }
+
+    public CreateReservationResponse registerReservation(CreateReservationRequest request) {
+        Reservation reservation = reservationService.validateReservationAndSaveIsEmpty(request);
+        return ReservationMapper.toCreateReservationResponse(reservation);
     }
 
 }

--- a/src/main/java/com/prgrms/catchtable/reservation/dto/mapper/ReservationMapper.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/dto/mapper/ReservationMapper.java
@@ -1,0 +1,21 @@
+package com.prgrms.catchtable.reservation.dto.mapper;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.prgrms.catchtable.reservation.domain.Reservation;
+import com.prgrms.catchtable.reservation.dto.response.CreateReservationResponse;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = PRIVATE)
+public class ReservationMapper {
+
+    public static CreateReservationResponse toCreateReservationResponse(Reservation reservation) {
+        return CreateReservationResponse.builder()
+            .shopName(reservation.getShop().getName())
+            .memberName("memberA")
+            .date(reservation.getReservationTime().getTime())
+            .peopleCount(reservation.getPeopleCount())
+            .build();
+    }
+
+}

--- a/src/main/java/com/prgrms/catchtable/reservation/repository/ReservationTimeRepository.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/repository/ReservationTimeRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ReservationTimeRepository extends JpaRepository<ReservationTime, Long> {
+
     @Query("select rt from ReservationTime rt join fetch rt.shop s where rt.id = :id")
     Optional<ReservationTime> findByIdWithShop(@Param("id") Long id);
 }

--- a/src/main/java/com/prgrms/catchtable/reservation/repository/ReservationTimeRepository.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/repository/ReservationTimeRepository.java
@@ -1,8 +1,12 @@
 package com.prgrms.catchtable.reservation.repository;
 
 import com.prgrms.catchtable.reservation.domain.ReservationTime;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ReservationTimeRepository extends JpaRepository<ReservationTime, Long> {
-
+    @Query("select rt from ReservationTime rt join fetch rt.shop s where rt.id = :id")
+    Optional<ReservationTime> findByIdWithShop(@Param("id") Long id);
 }

--- a/src/main/java/com/prgrms/catchtable/reservation/service/ReservationService.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/service/ReservationService.java
@@ -1,12 +1,16 @@
 package com.prgrms.catchtable.reservation.service;
 
+import static com.prgrms.catchtable.common.exception.ErrorCode.ALREADY_OCCUPIED_RESERVATION_TIME;
 import static com.prgrms.catchtable.common.exception.ErrorCode.ALREADY_PREOCCUPIED_RESERVATION_TIME;
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_TIME;
+import static com.prgrms.catchtable.reservation.domain.ReservationStatus.COMPLETED;
 
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
+import com.prgrms.catchtable.reservation.domain.Reservation;
 import com.prgrms.catchtable.reservation.domain.ReservationTime;
 import com.prgrms.catchtable.reservation.dto.request.CreateReservationRequest;
+import com.prgrms.catchtable.reservation.repository.ReservationRepository;
 import com.prgrms.catchtable.reservation.repository.ReservationTimeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReservationService {
 
     private final ReservationTimeRepository reservationTimeRepository;
+    private final ReservationRepository reservationRepository;
 
     @Transactional
     public ReservationTime validateReservationAndSave(CreateReservationRequest request) {
@@ -29,5 +34,25 @@ public class ReservationService {
         }
 
         return reservationTime;
+    }
+    
+    @Transactional
+    public Reservation validateReservationAndSaveIsEmpty(CreateReservationRequest request){
+        ReservationTime reservationTime = reservationTimeRepository.findByIdWithShop(
+            request.reservationTimeId()).
+            orElseThrow(() -> new NotFoundCustomException(NOT_EXIST_TIME));
+        
+        if(reservationTime.isOccupied()){
+            throw new BadRequestCustomException(ALREADY_OCCUPIED_RESERVATION_TIME);
+        }
+
+        Reservation reservation = Reservation.builder()
+            .status(COMPLETED)
+            .peopleCount(request.peopleCount())
+            .shop(reservationTime.getShop())
+            .reservationTime(reservationTime)
+            .build();
+        Reservation savedReservation = reservationRepository.save(reservation);
+        return savedReservation;
     }
 }

--- a/src/main/java/com/prgrms/catchtable/reservation/service/ReservationService.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/service/ReservationService.java
@@ -54,7 +54,6 @@ public class ReservationService {
             .shop(reservationTime.getShop())
             .reservationTime(reservationTime)
             .build();
-        Reservation savedReservation = reservationRepository.save(reservation);
-        return savedReservation;
+        return reservationRepository.save(reservation);
     }
 }

--- a/src/main/java/com/prgrms/catchtable/reservation/service/ReservationService.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/service/ReservationService.java
@@ -46,6 +46,8 @@ public class ReservationService {
             throw new BadRequestCustomException(ALREADY_OCCUPIED_RESERVATION_TIME);
         }
 
+        reservationTime.reverseOccupied();
+
         Reservation reservation = Reservation.builder()
             .status(COMPLETED)
             .peopleCount(request.peopleCount())

--- a/src/main/java/com/prgrms/catchtable/reservation/service/ReservationService.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/service/ReservationService.java
@@ -35,14 +35,14 @@ public class ReservationService {
 
         return reservationTime;
     }
-    
+
     @Transactional
-    public Reservation validateReservationAndSaveIsEmpty(CreateReservationRequest request){
+    public Reservation validateReservationAndSaveIsEmpty(CreateReservationRequest request) {
         ReservationTime reservationTime = reservationTimeRepository.findByIdWithShop(
-            request.reservationTimeId()).
+                request.reservationTimeId()).
             orElseThrow(() -> new NotFoundCustomException(NOT_EXIST_TIME));
-        
-        if(reservationTime.isOccupied()){
+
+        if (reservationTime.isOccupied()) {
             throw new BadRequestCustomException(ALREADY_OCCUPIED_RESERVATION_TIME);
         }
 

--- a/src/main/java/com/prgrms/catchtable/shop/domain/Shop.java
+++ b/src/main/java/com/prgrms/catchtable/shop/domain/Shop.java
@@ -52,9 +52,9 @@ public class Shop extends BaseEntity {
     private LocalTime closingTime;
 
 
-
     @Builder
-    public Shop(String name, BigDecimal rating, Category category, Address address, int capacity, LocalTime openingTime, LocalTime closingTime) {
+    public Shop(String name, BigDecimal rating, Category category, Address address, int capacity,
+        LocalTime openingTime, LocalTime closingTime) {
         this.name = name;
         this.rating = rating;
         this.category = category;
@@ -65,7 +65,7 @@ public class Shop extends BaseEntity {
     }
 
     public void validateIfShopOpened(LocalTime localTime) {
-        if (localTime.isBefore(openingTime)|| localTime.isAfter(closingTime)){
+        if (localTime.isBefore(openingTime) || localTime.isAfter(closingTime)) {
             throw new BadRequestCustomException(SHOP_NOT_RUNNING);
         }
     }

--- a/src/main/java/com/prgrms/catchtable/waiting/domain/WaitingStatus.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/domain/WaitingStatus.java
@@ -2,6 +2,7 @@ package com.prgrms.catchtable.waiting.domain;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
 @Getter
 @RequiredArgsConstructor
 public enum WaitingStatus {

--- a/src/main/java/com/prgrms/catchtable/waiting/dto/CreateWaitingRequest.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/dto/CreateWaitingRequest.java
@@ -7,4 +7,6 @@ import lombok.Builder;
 public record CreateWaitingRequest(
     @Positive(message = "인원은 1명 이상이어야 합니다.")
     int peopleCount
-){}
+) {
+
+}

--- a/src/main/java/com/prgrms/catchtable/waiting/dto/CreateWaitingResponse.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/dto/CreateWaitingResponse.java
@@ -10,4 +10,6 @@ public record CreateWaitingResponse(
     int peopleCount,
     int waitingNumber,
     int waitingOrder
-){}
+) {
+
+}

--- a/src/main/java/com/prgrms/catchtable/waiting/dto/WaitingMapper.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/dto/WaitingMapper.java
@@ -9,8 +9,10 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = PRIVATE)
 public class WaitingMapper {
+
     // dto -> entity
-    public static Waiting toWaiting(CreateWaitingRequest request, int waitingNumber, int waitingOrder, Member member, Shop shop){
+    public static Waiting toWaiting(CreateWaitingRequest request, int waitingNumber,
+        int waitingOrder, Member member, Shop shop) {
         return Waiting.builder()
             .waitingNumber(waitingNumber)
             .waitingOrder(waitingOrder)
@@ -20,7 +22,7 @@ public class WaitingMapper {
     }
 
     // entity -> dto
-    public static CreateWaitingResponse toCreateWaitingResponse(Waiting waiting){
+    public static CreateWaitingResponse toCreateWaitingResponse(Waiting waiting) {
         return CreateWaitingResponse.builder()
             .createdWaitingId(waiting.getId())
             .shopId(waiting.getShop().getId())

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/WaitingRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/WaitingRepository.java
@@ -4,14 +4,15 @@ import com.prgrms.catchtable.member.domain.Member;
 import com.prgrms.catchtable.shop.domain.Shop;
 import com.prgrms.catchtable.waiting.domain.Waiting;
 import com.prgrms.catchtable.waiting.domain.WaitingStatus;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface WaitingRepository extends JpaRepository<Waiting, Long> {
+
     boolean existsByMember(Member member);
-    Long countByShopAndStatusAndCreatedAtBetween(Shop shop, WaitingStatus status, LocalDateTime start, LocalDateTime end);
+
+    Long countByShopAndStatusAndCreatedAtBetween(Shop shop, WaitingStatus status,
+        LocalDateTime start, LocalDateTime end);
+
     Long countByShopAndCreatedAtBetween(Shop shop, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/prgrms/catchtable/waiting/service/WaitingService.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/service/WaitingService.java
@@ -25,11 +25,15 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Service
 public class WaitingService {
-    private final LocalDateTime START_DATE_TIME = LocalDateTime.of(LocalDate.now(), LocalTime.of(0,0,0));
-    private final LocalDateTime END_DATE_TIME = LocalDateTime.of(LocalDate.now(), LocalTime.of(23,59,59));
+
+    private final LocalDateTime START_DATE_TIME = LocalDateTime.of(LocalDate.now(),
+        LocalTime.of(0, 0, 0));
+    private final LocalDateTime END_DATE_TIME = LocalDateTime.of(LocalDate.now(),
+        LocalTime.of(23, 59, 59));
     private final WaitingRepository waitingRepository;
     private final MemberRepository memberRepository;
     private final ShopRepository shopRepository;
+
     public CreateWaitingResponse createWaiting(Long shopId, CreateWaitingRequest request) {
         // 연관 엔티티 조회
         Member member = getMemberEntity(1L);
@@ -43,32 +47,33 @@ public class WaitingService {
 
         // 대기 번호 생성
         int waitingNumber = (waitingRepository.countByShopAndStatusAndCreatedAtBetween(shop,
-            PROGRESS, START_DATE_TIME, END_DATE_TIME)).intValue()+1;
+            PROGRESS, START_DATE_TIME, END_DATE_TIME)).intValue() + 1;
 
         // 대기 순서 생성
         int waitingOrder = (waitingRepository.countByShopAndCreatedAtBetween(shop,
-            START_DATE_TIME, END_DATE_TIME)).intValue()+1;
+            START_DATE_TIME, END_DATE_TIME)).intValue() + 1;
 
         // waiting 저장
-        Waiting waiting = WaitingMapper.toWaiting(request, waitingNumber, waitingOrder, member, shop);
+        Waiting waiting = WaitingMapper.toWaiting(request, waitingNumber, waitingOrder, member,
+            shop);
         Waiting savedWaiting = waitingRepository.save(waiting);
 
         return WaitingMapper.toCreateWaitingResponse(savedWaiting);
     }
 
     private void validateIfMemberWaitingExists(Member member) {
-        if (waitingRepository.existsByMember(member)){
+        if (waitingRepository.existsByMember(member)) {
             throw new BadRequestCustomException(EXISTING_MEMBER_WAITING);
         }
     }
 
-    public Member getMemberEntity(Long memberId){
+    public Member getMemberEntity(Long memberId) {
         return memberRepository.findById(memberId).orElseThrow(
-            ()-> new NotFoundCustomException(NOT_EXIST_MEMBER)
+            () -> new NotFoundCustomException(NOT_EXIST_MEMBER)
         );
     }
 
-    public Shop getShopEntity(Long shopId){
+    public Shop getShopEntity(Long shopId) {
         return shopRepository.findById(shopId).orElseThrow(
             () -> new NotFoundCustomException(NOT_EXIST_SHOP)
         );

--- a/src/test/java/com/prgrms/catchtable/common/data/reservation/ReservationData.java
+++ b/src/test/java/com/prgrms/catchtable/common/data/reservation/ReservationData.java
@@ -6,7 +6,9 @@ import com.prgrms.catchtable.common.data.shop.ShopData;
 import com.prgrms.catchtable.reservation.domain.Reservation;
 import com.prgrms.catchtable.reservation.domain.ReservationTime;
 import com.prgrms.catchtable.reservation.dto.request.CreateReservationRequest;
+import com.prgrms.catchtable.shop.domain.Shop;
 import java.time.LocalDateTime;
+import org.springframework.test.util.ReflectionTestUtils;
 
 public class ReservationData {
 
@@ -30,7 +32,9 @@ public class ReservationData {
         ReservationTime reservationTime = ReservationTime.builder()
             .time(LocalDateTime.of(2024, 12, 31, 19, 30))
             .build();
-        reservationTime.insertShop(ShopData.getShop());
+        Shop shop = ShopData.getShop();
+        ReflectionTestUtils.setField(shop, "id", 1L);
+        reservationTime.insertShop(shop);
         reservationTime.reversePreOccupied();
         return reservationTime;
     }

--- a/src/test/java/com/prgrms/catchtable/member/MemberFixture.java
+++ b/src/test/java/com/prgrms/catchtable/member/MemberFixture.java
@@ -2,10 +2,10 @@ package com.prgrms.catchtable.member;
 
 import com.prgrms.catchtable.member.domain.Gender;
 import com.prgrms.catchtable.member.domain.Member;
-import com.prgrms.catchtable.shop.domain.Shop;
 import java.time.LocalDate;
 
 public class MemberFixture {
+
     public static Member member(String name) {
         return Member.builder()
             .name(name)

--- a/src/test/java/com/prgrms/catchtable/reservation/repository/ReservationTimeRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/repository/ReservationTimeRepositoryTest.java
@@ -1,0 +1,53 @@
+package com.prgrms.catchtable.reservation.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.prgrms.catchtable.common.data.reservation.ReservationData;
+import com.prgrms.catchtable.common.data.shop.ShopData;
+import com.prgrms.catchtable.common.exception.ErrorCode;
+import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
+import com.prgrms.catchtable.reservation.domain.ReservationTime;
+import com.prgrms.catchtable.shop.domain.Shop;
+import com.prgrms.catchtable.shop.repository.ShopRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class ReservationTimeRepositoryTest {
+
+    @Autowired
+    private ReservationTimeRepository reservationTimeRepository;
+    @Autowired
+    private ShopRepository shopRepository;
+
+    @Test
+    @DisplayName("예약시간과 그 시간의 매장까지 한번의 쿼리로 조회할 수 있다.")
+    void findReservationTimeWithShop() {
+        Shop shop = ShopData.getShop();
+        Shop savedShop = shopRepository.save(shop);
+
+        ReservationTime reservationTime = ReservationData.getReservationTimeNotPreOccupied();
+        reservationTime.insertShop(savedShop);
+        ReservationTime savedTime = reservationTimeRepository.save(reservationTime);
+
+        ReservationTime findReservationTime = reservationTimeRepository.findByIdWithShop(
+                savedTime.getId())
+            .orElseThrow(() -> new NotFoundCustomException(ErrorCode.NOT_EXIST_TIME));
+
+        assertAll(
+            () -> assertThat(findReservationTime.getShop().getName()).isEqualTo(shop.getName()),
+            () -> assertThat(findReservationTime.getShop().getCapacity()).isEqualTo(
+                shop.getCapacity()),
+            () -> assertThat(findReservationTime.getShop().getCategory()).isEqualTo(
+                shop.getCategory()),
+            () -> assertThat(findReservationTime.getShop().getRating()).isEqualTo(shop.getRating())
+        );
+
+
+    }
+}

--- a/src/test/java/com/prgrms/catchtable/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/service/ReservationServiceTest.java
@@ -1,6 +1,6 @@
 package com.prgrms.catchtable.reservation.service;
 
-import static com.prgrms.catchtable.reservation.domain.ReservationStatus.*;
+import static com.prgrms.catchtable.reservation.domain.ReservationStatus.COMPLETED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.when;
 import com.prgrms.catchtable.common.data.reservation.ReservationData;
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import com.prgrms.catchtable.reservation.domain.Reservation;
-import com.prgrms.catchtable.reservation.domain.ReservationStatus;
 import com.prgrms.catchtable.reservation.domain.ReservationTime;
 import com.prgrms.catchtable.reservation.dto.request.CreateReservationRequest;
 import com.prgrms.catchtable.reservation.repository.ReservationRepository;
@@ -26,6 +25,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class ReservationServiceTest {
+
     @Mock
     ReservationRepository reservationRepository;
     @Mock
@@ -75,7 +75,7 @@ class ReservationServiceTest {
 
     @Test
     @DisplayName("최종예약을 등록할 때 예약시간이 비었으면 성공적으로 예약 등록을 완료한다.")
-    void registerReservation(){
+    void registerReservation() {
         ReservationTime reservationTime = ReservationData.getReservationTimePreOccupied();
         CreateReservationRequest request = ReservationData.getCreateReservationRequest();
         Reservation reservation = Reservation.builder()
@@ -91,11 +91,13 @@ class ReservationServiceTest {
         Reservation findReservation = reservationService.validateReservationAndSaveIsEmpty(request);
 
         assertAll(
-            () -> assertThat(findReservation.getReservationTime().getTime()).isEqualTo(reservationTime.getTime()),
+            () -> assertThat(findReservation.getReservationTime().getTime()).isEqualTo(
+                reservationTime.getTime()),
             () -> assertThat(findReservation.getPeopleCount()).isEqualTo(request.peopleCount()),
             () -> assertThat(findReservation.getStatus()).isEqualTo(COMPLETED)
         );
     }
+
     @Test
     @DisplayName("최종예약을 등록할 때 타인이 이미 예약한 경우 예외가 발생한다.")
     void registerReservationAlreadyOccupied() {

--- a/src/test/java/com/prgrms/catchtable/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/service/ReservationServiceTest.java
@@ -1,14 +1,19 @@
 package com.prgrms.catchtable.reservation.service;
 
+import static com.prgrms.catchtable.reservation.domain.ReservationStatus.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import com.prgrms.catchtable.common.data.reservation.ReservationData;
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
+import com.prgrms.catchtable.reservation.domain.Reservation;
+import com.prgrms.catchtable.reservation.domain.ReservationStatus;
 import com.prgrms.catchtable.reservation.domain.ReservationTime;
 import com.prgrms.catchtable.reservation.dto.request.CreateReservationRequest;
+import com.prgrms.catchtable.reservation.repository.ReservationRepository;
 import com.prgrms.catchtable.reservation.repository.ReservationTimeRepository;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -21,7 +26,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class ReservationServiceTest {
-
+    @Mock
+    ReservationRepository reservationRepository;
     @Mock
     private ReservationTimeRepository reservationTimeRepository;
     @InjectMocks
@@ -66,4 +72,42 @@ class ReservationServiceTest {
 
 
     }
+
+    @Test
+    @DisplayName("최종예약을 등록할 때 예약시간이 비었으면 성공적으로 예약 등록을 완료한다.")
+    void registerReservation(){
+        ReservationTime reservationTime = ReservationData.getReservationTimePreOccupied();
+        CreateReservationRequest request = ReservationData.getCreateReservationRequest();
+        Reservation reservation = Reservation.builder()
+            .status(COMPLETED)
+            .peopleCount(request.peopleCount())
+            .shop(reservationTime.getShop())
+            .reservationTime(reservationTime)
+            .build();
+
+        when(reservationTimeRepository.findByIdWithShop(any(Long.class))).thenReturn(
+            Optional.of(reservationTime));
+        when(reservationRepository.save(any(Reservation.class))).thenReturn(reservation);
+        Reservation findReservation = reservationService.validateReservationAndSaveIsEmpty(request);
+
+        assertAll(
+            () -> assertThat(findReservation.getReservationTime().getTime()).isEqualTo(reservationTime.getTime()),
+            () -> assertThat(findReservation.getPeopleCount()).isEqualTo(request.peopleCount()),
+            () -> assertThat(findReservation.getStatus()).isEqualTo(COMPLETED)
+        );
+    }
+    @Test
+    @DisplayName("최종예약을 등록할 때 타인이 이미 예약한 경우 예외가 발생한다.")
+    void registerReservationAlreadyOccupied() {
+        ReservationTime reservationTime = ReservationData.getReservationTimePreOccupied();
+        CreateReservationRequest request = ReservationData.getCreateReservationRequest();
+
+        reservationTime.reverseOccupied();
+        when(reservationTimeRepository.findByIdWithShop(any(Long.class))).thenReturn(
+            Optional.of(reservationTime));
+
+        assertThrows(BadRequestCustomException.class,
+            () -> reservationService.validateReservationAndSaveIsEmpty(request));
+    }
+
 }

--- a/src/test/java/com/prgrms/catchtable/shop/domain/ShopTest.java
+++ b/src/test/java/com/prgrms/catchtable/shop/domain/ShopTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class ShopTest {
+
     @DisplayName("가게 영업 시간이 아닐 때는 예외를 발생시킨다.")
     @Test
     void validate_shop_not_running_time() {
@@ -28,15 +29,15 @@ class ShopTest {
 
     @DisplayName("가게 영업 시간 내에서는 예외를 발생시키지 않는다.")
     @Test
-    void validate_shop_running_time(){
+    void validate_shop_running_time() {
         //given
         LocalTime openingTime = LocalTime.of(11, 0);
-        LocalTime closingTime = LocalTime.of(21,0);
+        LocalTime closingTime = LocalTime.of(21, 0);
         Shop shop = ShopFixture.shop();
         //when, then
         assertDoesNotThrow(
-            ()->shop.validateIfShopOpened(openingTime));
+            () -> shop.validateIfShopOpened(openingTime));
         assertDoesNotThrow(
-            ()->shop.validateIfShopOpened(closingTime));
+            () -> shop.validateIfShopOpened(closingTime));
     }
 }

--- a/src/test/java/com/prgrms/catchtable/shop/fixture/ShopFixture.java
+++ b/src/test/java/com/prgrms/catchtable/shop/fixture/ShopFixture.java
@@ -7,15 +7,16 @@ import java.math.BigDecimal;
 import java.time.LocalTime;
 
 public class ShopFixture {
-    public static Shop shop(){
+
+    public static Shop shop() {
         return Shop.builder()
             .name("testShop")
             .rating(BigDecimal.valueOf(3.5))
             .category(Category.WESTERN_FOOD)
             .address(new Address("서울시", "중구"))
             .capacity(30)
-            .openingTime(LocalTime.of(11,0))
-            .closingTime(LocalTime.of(21,0))
+            .openingTime(LocalTime.of(11, 0))
+            .closingTime(LocalTime.of(21, 0))
             .build();
     }
 }

--- a/src/test/java/com/prgrms/catchtable/waiting/repository/WaitingRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/repository/WaitingRepositoryTest.java
@@ -37,11 +37,13 @@ class WaitingRepositoryTest {
     private Waiting waiting1;
     private Waiting waiting2;
     private Waiting waiting3;
-    private final LocalDateTime START_DATE_TIME = LocalDateTime.of(LocalDate.now(), LocalTime.of(0,0,0));
-    private final LocalDateTime END_DATE_TIME = LocalDateTime.of(LocalDate.now(), LocalTime.of(23,59,59));
+    private final LocalDateTime START_DATE_TIME = LocalDateTime.of(LocalDate.now(),
+        LocalTime.of(0, 0, 0));
+    private final LocalDateTime END_DATE_TIME = LocalDateTime.of(LocalDate.now(),
+        LocalTime.of(23, 59, 59));
 
     @BeforeEach
-    void setUp(){
+    void setUp() {
         Member member1 = MemberFixture.member("test1");
         Member member2 = MemberFixture.member("test2");
         Member member3 = MemberFixture.member("test3");
@@ -91,7 +93,8 @@ class WaitingRepositoryTest {
         waitingRepository.save(waiting2); //입장상태 대기 생성
 
         //when
-        Long count = waitingRepository.countByShopAndStatusAndCreatedAtBetween(shop,PROGRESS,START_DATE_TIME, END_DATE_TIME);
+        Long count = waitingRepository.countByShopAndStatusAndCreatedAtBetween(shop, PROGRESS,
+            START_DATE_TIME, END_DATE_TIME);
         //then
         assertThat(count).isEqualTo(1L);
     }
@@ -106,7 +109,8 @@ class WaitingRepositoryTest {
         waitingRepository.save(waiting2);
 
         //when
-        Long count = waitingRepository.countByShopAndCreatedAtBetween(shop,START_DATE_TIME, END_DATE_TIME);
+        Long count = waitingRepository.countByShopAndCreatedAtBetween(shop, START_DATE_TIME,
+            END_DATE_TIME);
         //then
         assertThat(count).isEqualTo(2L);
     }


### PR DESCRIPTION
close #32 
### ⛏ 작업 상세 내용

- 예약 최종 등록 로직 구현
- 예약 등록 로직 테스트
    - 정상 등록 테스트
    - 예외 발생 테스트

### 📝 작업 요약

- 예약 등록 로직 구현
- 코드 포맷팅

### **☑️** 중점적으로 리뷰 할 부분

- 예약 최종 등록이 선점권을 가진 상태에서 등록 하기 때문에 그 흐름으로 구현하였습니다.
- 추후에 선점권 api에서 동시성 이슈 제어를 할 예정이라 최종 등록에는 동시성 관련 로직이 없습니다.
- 이 부분들 고려해서 로직 봐주십쇼~
