### PR TITLE
대기 생성 API 수정 및 보완

### DIFF
--- a/src/docs/asciidoc/api/album/waiting.adoc
+++ b/src/docs/asciidoc/api/album/waiting.adoc
@@ -2,10 +2,11 @@
 === 웨이팅 등록
 
 ==== HTTP Request
+
 include::{snippets}/waiting-create/http-request.adoc[]
 include::{snippets}/waiting-create/request-fields.adoc[]
 
-
 ==== HTTP Response
+
 include::{snippets}/waiting-create/http-response.adoc[]
 include::{snippets}/waiting-create/response-fields.adoc[]

--- a/src/main/java/com/prgrms/catchtable/common/exception/ErrorCode.java
+++ b/src/main/java/com/prgrms/catchtable/common/exception/ErrorCode.java
@@ -15,7 +15,7 @@ public enum ErrorCode {
     NOT_EXIST_SHOP("존재하지 않는 매장입니다."),
     NOT_EXIST_TIME("존재하지 않는 예약 시간입니다."),
 
-    ALREADY_CANCELED_WAITING("이미 웨이팅을 취소하였습니다."),
+    CAN_NOT_COMPLETE_WAITING("입장 처리가 불가한 대기 상태입니다."),
     EXISTING_MEMBER_WAITING("이미 회원이 웨이팅 중인 가게가 존재합니다."),
     SHOP_NOT_RUNNING("가게가 영업시간이 아닙니다."),
     INTERNAL_SERVER_ERROR("내부 서버 오류입니다.");

--- a/src/main/java/com/prgrms/catchtable/waiting/controller/WaitingController.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/controller/WaitingController.java
@@ -3,6 +3,7 @@ package com.prgrms.catchtable.waiting.controller;
 import com.prgrms.catchtable.waiting.dto.CreateWaitingRequest;
 import com.prgrms.catchtable.waiting.dto.CreateWaitingResponse;
 import com.prgrms.catchtable.waiting.service.WaitingService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -20,7 +21,7 @@ public class WaitingController {
 
     @PostMapping("/{shopId}")
     public ResponseEntity<CreateWaitingResponse> createWaiting(@PathVariable("shopId") Long shopId,
-        @RequestBody CreateWaitingRequest request) {
+        @Valid @RequestBody CreateWaitingRequest request) {
         CreateWaitingResponse response = waitingService.createWaiting(shopId, request);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/prgrms/catchtable/waiting/controller/WaitingController.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/controller/WaitingController.java
@@ -19,10 +19,11 @@ public class WaitingController {
 
     private final WaitingService waitingService;
 
-    @PostMapping("/{shopId}")
+    @PostMapping("/{shopId}/{memberId}")
     public ResponseEntity<CreateWaitingResponse> createWaiting(@PathVariable("shopId") Long shopId,
+        @PathVariable("memberId") Long memberId,
         @Valid @RequestBody CreateWaitingRequest request) {
-        CreateWaitingResponse response = waitingService.createWaiting(shopId, request);
+        CreateWaitingResponse response = waitingService.createWaiting(shopId, memberId, request);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/prgrms/catchtable/waiting/dto/WaitingMapper.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/dto/WaitingMapper.java
@@ -11,25 +11,24 @@ import lombok.NoArgsConstructor;
 public class WaitingMapper {
 
     // dto -> entity
-    public static Waiting toWaiting(CreateWaitingRequest request, int waitingNumber,
-        int waitingOrder, Member member, Shop shop) {
+    public static Waiting toWaiting(CreateWaitingRequest request, int waitingNumber, Member member,
+        Shop shop) {
         return Waiting.builder()
             .waitingNumber(waitingNumber)
-            .waitingOrder(waitingOrder)
             .peopleCount(request.peopleCount())
             .member(member)
             .shop(shop).build();
     }
 
     // entity -> dto
-    public static CreateWaitingResponse toCreateWaitingResponse(Waiting waiting) {
+    public static CreateWaitingResponse toCreateWaitingResponse(Waiting waiting, int waitingOrder) {
         return CreateWaitingResponse.builder()
             .createdWaitingId(waiting.getId())
             .shopId(waiting.getShop().getId())
             .shopName(waiting.getShop().getName())
             .peopleCount(waiting.getPeopleCount())
             .waitingNumber(waiting.getWaitingNumber())
-            .waitingOrder(waiting.getWaitingOrder())
+            .waitingOrder(waitingOrder)
             .build();
     }
 }

--- a/src/main/java/com/prgrms/catchtable/waiting/service/WaitingService.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/service/WaitingService.java
@@ -46,19 +46,18 @@ public class WaitingService {
         validateIfMemberWaitingExists(member);
 
         // 대기 번호 생성
-        int waitingNumber = (waitingRepository.countByShopAndStatusAndCreatedAtBetween(shop,
-            PROGRESS, START_DATE_TIME, END_DATE_TIME)).intValue() + 1;
-
-        // 대기 순서 생성
-        int waitingOrder = (waitingRepository.countByShopAndCreatedAtBetween(shop,
+        int waitingNumber = (waitingRepository.countByShopAndCreatedAtBetween(shop,
             START_DATE_TIME, END_DATE_TIME)).intValue() + 1;
 
+        // 대기 순서 생성
+        int waitingOrder = (waitingRepository.countByShopAndStatusAndCreatedAtBetween(shop,
+            PROGRESS, START_DATE_TIME, END_DATE_TIME)).intValue() + 1;
+
         // waiting 저장
-        Waiting waiting = WaitingMapper.toWaiting(request, waitingNumber, waitingOrder, member,
-            shop);
+        Waiting waiting = WaitingMapper.toWaiting(request, waitingNumber, member, shop);
         Waiting savedWaiting = waitingRepository.save(waiting);
 
-        return WaitingMapper.toCreateWaitingResponse(savedWaiting);
+        return WaitingMapper.toCreateWaitingResponse(savedWaiting, waitingOrder);
     }
 
     private void validateIfMemberWaitingExists(Member member) {

--- a/src/main/java/com/prgrms/catchtable/waiting/service/WaitingService.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/service/WaitingService.java
@@ -34,9 +34,10 @@ public class WaitingService {
     private final MemberRepository memberRepository;
     private final ShopRepository shopRepository;
 
-    public CreateWaitingResponse createWaiting(Long shopId, CreateWaitingRequest request) {
+    public CreateWaitingResponse createWaiting(Long shopId, Long memberId,
+        CreateWaitingRequest request) {
         // 연관 엔티티 조회
-        Member member = getMemberEntity(1L);
+        Member member = getMemberEntity(memberId);
         Shop shop = getShopEntity(shopId);
 
         // shop 영업 중인지 검증

--- a/src/test/java/com/prgrms/catchtable/member/MemberFixture.java
+++ b/src/test/java/com/prgrms/catchtable/member/MemberFixture.java
@@ -6,9 +6,10 @@ import java.time.LocalDate;
 
 public class MemberFixture {
 
-    public static Member member(String name) {
+    public static Member member(String email) {
         return Member.builder()
-            .name(name)
+            .name("member")
+            .email(email)
             .phoneNumber("010-1111-1111")
             .gender(Gender.FEMALE)
             .dateBirth(LocalDate.parse("2008-12-18"))

--- a/src/test/java/com/prgrms/catchtable/shop/domain/ShopTest.java
+++ b/src/test/java/com/prgrms/catchtable/shop/domain/ShopTest.java
@@ -15,8 +15,8 @@ class ShopTest {
     @Test
     void validate_shop_not_running_time() {
         //given
-        LocalTime beforeOpeningTime = LocalTime.of(10, 59);
-        LocalTime afterClosingTime = LocalTime.of(21, 1);
+        LocalTime beforeOpeningTime = LocalTime.of(5, 59);
+        LocalTime afterClosingTime = LocalTime.of(23, 1);
         Shop shop = ShopFixture.shop();
         //when, then
         assertThrows(
@@ -31,8 +31,8 @@ class ShopTest {
     @Test
     void validate_shop_running_time() {
         //given
-        LocalTime openingTime = LocalTime.of(11, 0);
-        LocalTime closingTime = LocalTime.of(21, 0);
+        LocalTime openingTime = LocalTime.of(6, 0);
+        LocalTime closingTime = LocalTime.of(23, 0);
         Shop shop = ShopFixture.shop();
         //when, then
         assertDoesNotThrow(

--- a/src/test/java/com/prgrms/catchtable/shop/fixture/ShopFixture.java
+++ b/src/test/java/com/prgrms/catchtable/shop/fixture/ShopFixture.java
@@ -19,4 +19,16 @@ public class ShopFixture {
             .closingTime(LocalTime.of(23, 0))
             .build();
     }
+
+    public static Shop shopWith24() {
+        return Shop.builder()
+            .name("testShop")
+            .rating(BigDecimal.valueOf(3.5))
+            .category(Category.WESTERN_FOOD)
+            .address(new Address("서울시", "중구"))
+            .capacity(30)
+            .openingTime(LocalTime.of(0, 0))
+            .closingTime(LocalTime.of(23, 59,59))
+            .build();
+    }
 }

--- a/src/test/java/com/prgrms/catchtable/shop/fixture/ShopFixture.java
+++ b/src/test/java/com/prgrms/catchtable/shop/fixture/ShopFixture.java
@@ -15,8 +15,8 @@ public class ShopFixture {
             .category(Category.WESTERN_FOOD)
             .address(new Address("서울시", "중구"))
             .capacity(30)
-            .openingTime(LocalTime.of(11, 0))
-            .closingTime(LocalTime.of(21, 0))
+            .openingTime(LocalTime.of(6, 0))
+            .closingTime(LocalTime.of(23, 0))
             .build();
     }
 }

--- a/src/test/java/com/prgrms/catchtable/shop/fixture/ShopFixture.java
+++ b/src/test/java/com/prgrms/catchtable/shop/fixture/ShopFixture.java
@@ -28,7 +28,7 @@ public class ShopFixture {
             .address(new Address("서울시", "중구"))
             .capacity(30)
             .openingTime(LocalTime.of(0, 0))
-            .closingTime(LocalTime.of(23, 59,59))
+            .closingTime(LocalTime.of(23, 59, 59))
             .build();
     }
 }

--- a/src/test/java/com/prgrms/catchtable/waiting/controller/WaitingControllerDocsTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/controller/WaitingControllerDocsTest.java
@@ -45,9 +45,9 @@ class WaitingControllerDocsTest extends RestDocsSupport {
             .peopleCount(2)
             .build();
 
-        given(waitingService.createWaiting(1L, request)).willReturn(response);
+        given(waitingService.createWaiting(1L, 1L, request)).willReturn(response);
 
-        mockMvc.perform(post("/waitings/{shopId}", 1)
+        mockMvc.perform(post("/waitings/{shopId}/{memberId}", 1, 1)
                 .contentType(APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isOk())

--- a/src/test/java/com/prgrms/catchtable/waiting/controller/WaitingControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/controller/WaitingControllerTest.java
@@ -21,14 +21,16 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 class WaitingControllerTest extends BaseIntegrationTest {
 
     @Autowired
-    MemberRepository memberRepository;
+    private MemberRepository memberRepository;
     @Autowired
-    WaitingRepository waitingRepository;
-    List<Waiting> waitings;
+    private WaitingRepository waitingRepository;
+    private List<Waiting> waitings;
     @Autowired
     private ShopRepository shopRepository;
     private Shop shop;

--- a/src/test/java/com/prgrms/catchtable/waiting/controller/WaitingControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/controller/WaitingControllerTest.java
@@ -36,7 +36,7 @@ class WaitingControllerTest extends BaseIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        shop = ShopFixture.shop();
+        shop = ShopFixture.shopWith24();
         shopRepository.save(shop);
         member1 = MemberFixture.member("test1@naver.com");
         member2 = MemberFixture.member("test2@naver.com");
@@ -63,9 +63,6 @@ class WaitingControllerTest extends BaseIntegrationTest {
     @DisplayName("웨이팅 생성 API를 호출할 수 있다.")
     @Test
     void createWaiting() throws Exception {
-        System.out.println("member1.getId( = " + member1.getId());
-        System.out.println("member2.getId( = " + member2.getId());
-        System.out.println("member3.getId( = " + member3.getId());
         //given
         CreateWaitingRequest request = CreateWaitingRequest
             .builder()

--- a/src/test/java/com/prgrms/catchtable/waiting/controller/WaitingControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/controller/WaitingControllerTest.java
@@ -32,25 +32,25 @@ class WaitingControllerTest extends BaseIntegrationTest {
     @Autowired
     private ShopRepository shopRepository;
     private Shop shop;
+    private Member member1, member2, member3;
 
     @BeforeEach
     void setUp() {
         shop = ShopFixture.shop();
         shopRepository.save(shop);
-
-        Member member1 = MemberFixture.member("test1@naver.com");
-        Member member2 = MemberFixture.member("test2@naver.com");
-        Member member3 = MemberFixture.member("test3@naver.com");
+        member1 = MemberFixture.member("test1@naver.com");
+        member2 = MemberFixture.member("test2@naver.com");
+        member3 = MemberFixture.member("test3@naver.com");
         memberRepository.saveAll(List.of(member1, member2, member3));
 
         Waiting waiting1 = Waiting.builder()
-            .member(member2)
+            .member(member1)
             .shop(shop)
             .waitingNumber(1)
             .peopleCount(2)
             .build();
         Waiting waiting2 = Waiting.builder()
-            .member(member3)
+            .member(member2)
             .shop(shop)
             .waitingNumber(2)
             .peopleCount(2)
@@ -59,15 +59,19 @@ class WaitingControllerTest extends BaseIntegrationTest {
         waiting2.completeWaiting();
     }
 
+
     @DisplayName("웨이팅 생성 API를 호출할 수 있다.")
     @Test
     void createWaiting() throws Exception {
+        System.out.println("member1.getId( = " + member1.getId());
+        System.out.println("member2.getId( = " + member2.getId());
+        System.out.println("member3.getId( = " + member3.getId());
         //given
         CreateWaitingRequest request = CreateWaitingRequest
             .builder()
             .peopleCount(2).build();
         // when, then
-        mockMvc.perform(post("/waitings/{shopId}", 1)
+        mockMvc.perform(post("/waitings/{shopId}/{memberId}", shop.getId(), member3.getId())
                 .contentType(APPLICATION_JSON)
                 .content(asJsonString(request)))
             .andExpect(status().isOk())

--- a/src/test/java/com/prgrms/catchtable/waiting/controller/WaitingControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/controller/WaitingControllerTest.java
@@ -25,16 +25,13 @@ import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 class WaitingControllerTest extends BaseIntegrationTest {
 
     @Autowired
-    private ShopRepository shopRepository;
-
-    @Autowired
     MemberRepository memberRepository;
-
     @Autowired
     WaitingRepository waitingRepository;
-
-    private Shop shop;
     List<Waiting> waitings;
+    @Autowired
+    private ShopRepository shopRepository;
+    private Shop shop;
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/com/prgrms/catchtable/waiting/controller/WaitingControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/controller/WaitingControllerTest.java
@@ -1,0 +1,85 @@
+package com.prgrms.catchtable.waiting.controller;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.prgrms.catchtable.common.base.BaseIntegrationTest;
+import com.prgrms.catchtable.member.MemberFixture;
+import com.prgrms.catchtable.member.domain.Member;
+import com.prgrms.catchtable.member.repository.MemberRepository;
+import com.prgrms.catchtable.shop.domain.Shop;
+import com.prgrms.catchtable.shop.fixture.ShopFixture;
+import com.prgrms.catchtable.shop.repository.ShopRepository;
+import com.prgrms.catchtable.waiting.domain.Waiting;
+import com.prgrms.catchtable.waiting.dto.CreateWaitingRequest;
+import com.prgrms.catchtable.waiting.repository.WaitingRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+
+class WaitingControllerTest extends BaseIntegrationTest {
+
+    @Autowired
+    private ShopRepository shopRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    WaitingRepository waitingRepository;
+
+    private Shop shop;
+    List<Waiting> waitings;
+
+    @BeforeEach
+    void setUp() {
+        shop = ShopFixture.shop();
+        shopRepository.save(shop);
+
+        Member member1 = MemberFixture.member("test1@naver.com");
+        Member member2 = MemberFixture.member("test2@naver.com");
+        Member member3 = MemberFixture.member("test3@naver.com");
+        memberRepository.saveAll(List.of(member1, member2, member3));
+
+        Waiting waiting1 = Waiting.builder()
+            .member(member2)
+            .shop(shop)
+            .waitingNumber(1)
+            .peopleCount(2)
+            .build();
+        Waiting waiting2 = Waiting.builder()
+            .member(member3)
+            .shop(shop)
+            .waitingNumber(2)
+            .peopleCount(2)
+            .build();
+        waitings = waitingRepository.saveAll(List.of(waiting1, waiting2));
+        waiting2.completeWaiting();
+    }
+
+    @DisplayName("웨이팅 생성 API를 호출할 수 있다.")
+    @Test
+    void createWaiting() throws Exception {
+        //given
+        CreateWaitingRequest request = CreateWaitingRequest
+            .builder()
+            .peopleCount(2).build();
+        // when, then
+        mockMvc.perform(post("/waitings/{shopId}", 1)
+                .contentType(APPLICATION_JSON)
+                .content(asJsonString(request)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.shopId").value(shop.getId()))
+            .andExpect(jsonPath("$.shopName").value(shop.getName()))
+            .andExpect(jsonPath("$.waitingOrder").value(2))
+            .andExpect(jsonPath("$.waitingNumber").value(waitings.size() + 1))
+            .andExpect(jsonPath("$.peopleCount").value(request.peopleCount()))
+            .andDo(MockMvcResultHandlers.print());
+
+    }
+}

--- a/src/test/java/com/prgrms/catchtable/waiting/fixture/WaitingFixture.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/fixture/WaitingFixture.java
@@ -1,0 +1,24 @@
+package com.prgrms.catchtable.waiting.fixture;
+
+import com.prgrms.catchtable.member.domain.Member;
+import com.prgrms.catchtable.shop.domain.Shop;
+import com.prgrms.catchtable.waiting.domain.Waiting;
+
+public class WaitingFixture {
+
+    public static Waiting waiting(Member member, Shop shop, int waitingNumber) {
+        return Waiting.builder()
+            .member(member)
+            .shop(shop)
+            .waitingNumber(waitingNumber)
+            .peopleCount(2)
+            .build();
+    }
+
+    public static Waiting completedWaiting(Member member, Shop shop, int waitingNumber) {
+        Waiting waiting = waiting(member, shop, waitingNumber);
+        waiting.completeWaiting();
+        return waiting;
+    }
+
+}

--- a/src/test/java/com/prgrms/catchtable/waiting/repository/WaitingRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/repository/WaitingRepositoryTest.java
@@ -26,21 +26,19 @@ import org.springframework.test.util.ReflectionTestUtils;
 @SpringBootTest
 class WaitingRepositoryTest {
 
+    private final LocalDateTime START_DATE_TIME = LocalDateTime.of(LocalDate.now(),
+        LocalTime.of(0, 0, 0));
+    private final LocalDateTime END_DATE_TIME = LocalDateTime.of(LocalDate.now(),
+        LocalTime.of(23, 59, 59));
     @Autowired
     private WaitingRepository waitingRepository;
-
     @Autowired
     private MemberRepository memberRepository;
-
     @Autowired
     private ShopRepository shopRepository;
     private Shop shop;
     private Member member1, member2, member3;
     private Waiting yesterdayWaiting, completedWaiting, normalWaiting;
-    private final LocalDateTime START_DATE_TIME = LocalDateTime.of(LocalDate.now(),
-        LocalTime.of(0, 0, 0));
-    private final LocalDateTime END_DATE_TIME = LocalDateTime.of(LocalDate.now(),
-        LocalTime.of(23, 59, 59));
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/com/prgrms/catchtable/waiting/repository/WaitingRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/repository/WaitingRepositoryTest.java
@@ -15,15 +15,18 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
 
 
 @SpringBootTest
+@Transactional
 class WaitingRepositoryTest {
 
     private final LocalDateTime START_DATE_TIME = LocalDateTime.of(LocalDate.now(),
@@ -49,6 +52,13 @@ class WaitingRepositoryTest {
 
         shop = ShopFixture.shop();
         shopRepository.save(shop);
+    }
+
+    @AfterEach
+    void clear() {
+        memberRepository.deleteAll();
+        waitingRepository.deleteAll();
+        shopRepository.deleteAll();
     }
 
     @DisplayName("특정 가게의 당일 대기 번호를 조회할 수 있다.")

--- a/src/test/java/com/prgrms/catchtable/waiting/repository/WaitingRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/repository/WaitingRepositoryTest.java
@@ -10,10 +10,11 @@ import com.prgrms.catchtable.shop.domain.Shop;
 import com.prgrms.catchtable.shop.fixture.ShopFixture;
 import com.prgrms.catchtable.shop.repository.ShopRepository;
 import com.prgrms.catchtable.waiting.domain.Waiting;
-import com.prgrms.catchtable.waiting.domain.WaitingStatus;
+import com.prgrms.catchtable.waiting.fixture.WaitingFixture;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,14 +28,15 @@ class WaitingRepositoryTest {
 
     @Autowired
     private WaitingRepository waitingRepository;
+
     @Autowired
     private MemberRepository memberRepository;
+
     @Autowired
     private ShopRepository shopRepository;
     private Shop shop;
-    private Waiting waiting1;
-    private Waiting waiting2;
-    private Waiting waiting3;
+    private Member member1, member2, member3;
+    private Waiting yesterdayWaiting, completedWaiting, normalWaiting;
     private final LocalDateTime START_DATE_TIME = LocalDateTime.of(LocalDate.now(),
         LocalTime.of(0, 0, 0));
     private final LocalDateTime END_DATE_TIME = LocalDateTime.of(LocalDate.now(),
@@ -42,74 +44,50 @@ class WaitingRepositoryTest {
 
     @BeforeEach
     void setUp() {
-        Member member1 = MemberFixture.member("test1");
-        Member member2 = MemberFixture.member("test2");
-        Member member3 = MemberFixture.member("test3");
-
-        memberRepository.save(member1);
-        memberRepository.save(member2);
-        memberRepository.save(member3);
+        member1 = MemberFixture.member("test1");
+        member2 = MemberFixture.member("test2");
+        member3 = MemberFixture.member("test3");
+        memberRepository.saveAll(List.of(member1, member2, member3));
 
         shop = ShopFixture.shop();
         shopRepository.save(shop);
-
-        waiting1 = Waiting.builder()
-            .member(member1)
-            .shop(shop)
-            .waitingNumber(1)
-            .waitingOrder(1)
-            .peopleCount(2)
-            .build();
-
-        waiting2 = Waiting.builder()
-            .member(member2)
-            .shop(shop)
-            .waitingNumber(2)
-            .waitingOrder(2)
-            .peopleCount(2)
-            .build();
-
-        waiting3 = Waiting.builder()
-            .member(member3)
-            .shop(shop)
-            .waitingNumber(3)
-            .waitingOrder(3)
-            .peopleCount(2)
-            .build();
-        waitingRepository.save(waiting1);
-        waitingRepository.save(waiting2);
-        waitingRepository.save(waiting3);
     }
 
-    @DisplayName("특정 가게의 당일 대기 인원을 조회할 수 있다.")
-    @Test
-    void countByShopAndStatusAndCreatedAtBetween() {
-        //given
-        ReflectionTestUtils.setField(waiting1, "createdAt", LocalDateTime.now().minusDays(1));
-        waitingRepository.save(waiting1); //어제자 대기 생성
-        ReflectionTestUtils.setField(waiting2, "status", WaitingStatus.COMPLETED);
-        waitingRepository.save(waiting2); //입장상태 대기 생성
-
-        //when
-        Long count = waitingRepository.countByShopAndStatusAndCreatedAtBetween(shop, PROGRESS,
-            START_DATE_TIME, END_DATE_TIME);
-        //then
-        assertThat(count).isEqualTo(1L);
-    }
-
-    @DisplayName("특정 가게의 당일 대기 인원을 조회할 수 있다.")
+    @DisplayName("특정 가게의 당일 대기 번호를 조회할 수 있다.")
     @Test
     void countByShopAndCreatedAtBetween() {
-        //given
-        ReflectionTestUtils.setField(waiting1, "createdAt", LocalDateTime.now().minusDays(1));
-        waitingRepository.save(waiting1);
-        ReflectionTestUtils.setField(waiting2, "status", WaitingStatus.COMPLETED);
-        waitingRepository.save(waiting2);
+        yesterdayWaiting = WaitingFixture.waiting(member1, shop, 1);
+        completedWaiting = WaitingFixture.completedWaiting(member2, shop, 2);
+        normalWaiting = WaitingFixture.waiting(member3, shop, 3);
+        waitingRepository.saveAll(List.of(yesterdayWaiting, completedWaiting, normalWaiting));
+
+        ReflectionTestUtils.setField(yesterdayWaiting, "createdAt",
+            LocalDateTime.now().minusDays(1));
+        waitingRepository.save(yesterdayWaiting);
 
         //when
         Long count = waitingRepository.countByShopAndCreatedAtBetween(shop, START_DATE_TIME,
             END_DATE_TIME);
         //then
-        assertThat(count).isEqualTo(2L);
+        assertThat(count).isEqualTo(2L); //waiting2, waiting3
+    }
+
+    @DisplayName("특정 가게의 당일 대기 순서를 조회할 수 있다.")
+    @Test
+    void countByShopAndStatusAndCreatedAtBetween() {
+        yesterdayWaiting = WaitingFixture.waiting(member1, shop, 1);
+        completedWaiting = WaitingFixture.completedWaiting(member2, shop, 2);
+        normalWaiting = WaitingFixture.waiting(member3, shop, 3);
+        waitingRepository.saveAll(List.of(yesterdayWaiting, completedWaiting, normalWaiting));
+
+        ReflectionTestUtils.setField(yesterdayWaiting, "createdAt",
+            LocalDateTime.now().minusDays(1));
+        waitingRepository.save(yesterdayWaiting);
+
+        //when
+        Long count = waitingRepository.countByShopAndStatusAndCreatedAtBetween(shop, PROGRESS,
+            START_DATE_TIME, END_DATE_TIME);
+        //then
+        assertThat(count).isEqualTo(1L); //waiting3
     }
 }

--- a/src/test/java/com/prgrms/catchtable/waiting/service/WaitingServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/service/WaitingServiceTest.java
@@ -51,12 +51,12 @@ class WaitingServiceTest {
             .build();
         doNothing().when(shop).validateIfShopOpened(any(LocalTime.class));
         given(shopRepository.findById(1L)).willReturn(Optional.of(shop));
-        given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+        given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
         given(waitingRepository.existsByMember(member)).willReturn(false);
         given(waitingRepository.save(any(Waiting.class))).willReturn(waiting);
 
         //when
-        CreateWaitingResponse response = waitingService.createWaiting(1L, request);
+        CreateWaitingResponse response = waitingService.createWaiting(1L, member.getId(), request);
         //then
         assertAll(
             () -> assertThat(response.peopleCount()).isEqualTo(2),

--- a/src/test/java/com/prgrms/catchtable/waiting/service/WaitingServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/service/WaitingServiceTest.java
@@ -47,7 +47,6 @@ class WaitingServiceTest {
             .member(member)
             .shop(shop)
             .waitingNumber(1)
-            .waitingOrder(1)
             .peopleCount(2)
             .build();
         doNothing().when(shop).validateIfShopOpened(any(LocalTime.class));


### PR DESCRIPTION
### ⛏ 작업 상세 내용

- 충돌 해결
  - 기존 커밋 날리고 재 커밋 및 푸시
  
- waitingOrder 필드 삭제
  - 엔티티, service, dto, service test code 수정
 
- 엔티티 Waiting 필드명 수정
  - delayRemainingCount -> postponeRemainingCount

- 서비스 코드 잘못된 로직 수정
  - waitingNumber, waitingOrder 서로 다른 값 대입한 것 수정

- 컨트롤러 통합 테스트 작성
- MemberFixture 파라미터 수정
   - name 아닌 email 넘겨주도록 
 - WaitingFixture 생성
   - 웨이팅 입장, 기본 웨이팅 fixture 생성
   - WaitingRepositoryTest 에서 사용

### 📝 작업 요약

- Waiting Entity 필드 수정
- 통합 테스트 작성
- Fixture 생성 및 수정

### **☑️** 중점적으로 리뷰 할 부분

- waitingRepositoryTest
