### PR TITLE
feat : 예약 등록 API 구현

### DIFF
--- a/src/main/java/com/prgrms/catchtable/reservation/controller/ReservationController.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/controller/ReservationController.java
@@ -24,7 +24,8 @@ public class ReservationController {
     }
 
     @PostMapping("/success")
-    public ResponseEntity<CreateReservationResponse> registerReservation(@RequestBody CreateReservationRequest request){
+    public ResponseEntity<CreateReservationResponse> registerReservation(
+        @RequestBody CreateReservationRequest request) {
         return ResponseEntity.ok(reservationFacade.registerReservation(request));
     }
 }

--- a/src/main/java/com/prgrms/catchtable/reservation/controller/ReservationController.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/controller/ReservationController.java
@@ -18,8 +18,13 @@ public class ReservationController {
     private final ReservationFacade reservationFacade;
 
     @PostMapping
-    public ResponseEntity<CreateReservationResponse> createReservationResponse(
+    public ResponseEntity<CreateReservationResponse> preOccupyReservation(
         @RequestBody CreateReservationRequest request) {
         return ResponseEntity.ok(reservationFacade.preOccupyReservation(request));
+    }
+
+    @PostMapping("/success")
+    public ResponseEntity<CreateReservationResponse> registerReservation(@RequestBody CreateReservationRequest request){
+        return ResponseEntity.ok(reservationFacade.registerReservation(request));
     }
 }

--- a/src/test/java/com/prgrms/catchtable/common/base/BaseIntegrationTest.java
+++ b/src/test/java/com/prgrms/catchtable/common/base/BaseIntegrationTest.java
@@ -5,7 +5,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/src/test/java/com/prgrms/catchtable/common/base/BaseIntegrationTest.java
+++ b/src/test/java/com/prgrms/catchtable/common/base/BaseIntegrationTest.java
@@ -8,7 +8,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
-@Transactional
 @AutoConfigureMockMvc
 public abstract class BaseIntegrationTest {
 

--- a/src/test/java/com/prgrms/catchtable/facade/ReservationFacadeTest.java
+++ b/src/test/java/com/prgrms/catchtable/facade/ReservationFacadeTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import com.prgrms.catchtable.common.data.reservation.ReservationData;
+import com.prgrms.catchtable.reservation.fixture.ReservationFixture;
 import com.prgrms.catchtable.reservation.domain.ReservationTime;
 import com.prgrms.catchtable.reservation.dto.request.CreateReservationRequest;
 import com.prgrms.catchtable.reservation.dto.response.CreateReservationResponse;
@@ -31,8 +31,8 @@ class ReservationFacadeTest {
     @Test
     @DisplayName("예약을 검증하고 선점권을 true로 바꾸는 것에 성공한다.")
     void preOccupyReservation() {
-        ReservationTime reservationTime = ReservationData.getReservationTimeNotPreOccupied();
-        CreateReservationRequest request = ReservationData.getCreateReservationRequestWithId(
+        ReservationTime reservationTime = ReservationFixture.getReservationTimeNotPreOccupied();
+        CreateReservationRequest request = ReservationFixture.getCreateReservationRequestWithId(
             reservationTime.getId());
 
         when(reservationService.validateReservationAndSave(

--- a/src/test/java/com/prgrms/catchtable/reservation/controller/ReservationControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/controller/ReservationControllerTest.java
@@ -8,26 +8,46 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.prgrms.catchtable.common.base.BaseIntegrationTest;
 import com.prgrms.catchtable.common.data.reservation.ReservationData;
+import com.prgrms.catchtable.common.data.shop.ShopData;
 import com.prgrms.catchtable.reservation.domain.ReservationTime;
 import com.prgrms.catchtable.reservation.dto.request.CreateReservationRequest;
 import com.prgrms.catchtable.reservation.repository.ReservationTimeRepository;
+import com.prgrms.catchtable.shop.domain.Shop;
+import com.prgrms.catchtable.shop.repository.ShopRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
-
+@Transactional
 class ReservationControllerTest extends BaseIntegrationTest {
 
     @Autowired
     private ReservationTimeRepository reservationTimeRepository;
 
+    @Autowired
+    private ShopRepository shopRepository;
+
+    @BeforeEach
+    void setUp(){
+        Shop shop = ShopData.getShop();
+        Shop savedShop = shopRepository.save(shop);
+
+        ReservationTime reservationTime = ReservationData.getReservationTimeNotPreOccupied();
+        reservationTime.insertShop(savedShop);
+        reservationTimeRepository.save(reservationTime);
+    }
+
     @Test
     @DisplayName("예약 선점 api 호출에 성공한다.")
     void preOccupyReservation() throws Exception {
-        ReservationTime reservationTime = ReservationData.getReservationTimeNotPreOccupied();
-        ReservationTime savedReservationTime = reservationTimeRepository.save(reservationTime);
+        List<ReservationTime> all = reservationTimeRepository.findAll();
+        ReservationTime reservationTime = all.get(0);
+
         CreateReservationRequest request = ReservationData.getCreateReservationRequestWithId(
-            savedReservationTime.getId());
+            reservationTime.getId());
 
         mockMvc.perform(post("/reservations")
                 .contentType(APPLICATION_JSON)
@@ -41,10 +61,11 @@ class ReservationControllerTest extends BaseIntegrationTest {
     @Test
     @DisplayName("선점 api 호출 시 선점권이 획득 되었다가 지정 시간 이후에 획득이 풀린다.")
     void schedulerTest() throws Exception {
-        ReservationTime reservationTime = ReservationData.getReservationTimeNotPreOccupied();
-        ReservationTime savedReservationTime = reservationTimeRepository.save(reservationTime);
+        List<ReservationTime> all = reservationTimeRepository.findAll();
+        ReservationTime reservationTime = all.get(0);
+
         CreateReservationRequest request = ReservationData.getCreateReservationRequestWithId(
-            savedReservationTime.getId());
+            reservationTime.getId());
 
         mockMvc.perform(post("/reservations")
             .contentType(APPLICATION_JSON)
@@ -55,5 +76,23 @@ class ReservationControllerTest extends BaseIntegrationTest {
         assertThat(reservationTime.isPreOccupied()).isFalse();
     }
 
+    @Test
+    void resigerReservation() throws Exception {
+        List<ReservationTime> all = reservationTimeRepository.findAll();
+        ReservationTime reservationTime = all.get(0);
+
+        CreateReservationRequest request = ReservationData.getCreateReservationRequestWithId(
+            reservationTime.getId());
+
+        mockMvc.perform(post("/reservations/success")
+            .contentType(APPLICATION_JSON)
+            .content(asJsonString(request)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.shopName").value(reservationTime.getShop().getName()))
+            .andExpect(jsonPath("$.date").value(reservationTime.getTime().toString()))
+            .andExpect(jsonPath("$.peopleCount").value(request.peopleCount()));
+
+        assertThat(reservationTime.isOccupied()).isTrue();
+    }
 
 }

--- a/src/test/java/com/prgrms/catchtable/reservation/controller/ReservationControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/controller/ReservationControllerTest.java
@@ -8,7 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.prgrms.catchtable.common.base.BaseIntegrationTest;
-import com.prgrms.catchtable.common.data.reservation.ReservationData;
+import com.prgrms.catchtable.reservation.fixture.ReservationFixture;
 import com.prgrms.catchtable.common.data.shop.ShopData;
 import com.prgrms.catchtable.reservation.domain.ReservationTime;
 import com.prgrms.catchtable.reservation.dto.request.CreateReservationRequest;
@@ -36,7 +36,7 @@ class ReservationControllerTest extends BaseIntegrationTest {
         Shop shop = ShopData.getShop();
         Shop savedShop = shopRepository.save(shop);
 
-        ReservationTime reservationTime = ReservationData.getReservationTimeNotPreOccupied();
+        ReservationTime reservationTime = ReservationFixture.getReservationTimeNotPreOccupied();
         reservationTime.insertShop(savedShop);
         reservationTimeRepository.save(reservationTime);
     }
@@ -47,7 +47,7 @@ class ReservationControllerTest extends BaseIntegrationTest {
         List<ReservationTime> all = reservationTimeRepository.findAll();
         ReservationTime reservationTime = all.get(0);
 
-        CreateReservationRequest request = ReservationData.getCreateReservationRequestWithId(
+        CreateReservationRequest request = ReservationFixture.getCreateReservationRequestWithId(
             reservationTime.getId());
 
         mockMvc.perform(post("/reservations")
@@ -65,7 +65,7 @@ class ReservationControllerTest extends BaseIntegrationTest {
         List<ReservationTime> all = reservationTimeRepository.findAll();
         ReservationTime reservationTime = all.get(0);
 
-        CreateReservationRequest request = ReservationData.getCreateReservationRequestWithId(
+        CreateReservationRequest request = ReservationFixture.getCreateReservationRequestWithId(
             reservationTime.getId());
 
         mockMvc.perform(post("/reservations")
@@ -83,7 +83,7 @@ class ReservationControllerTest extends BaseIntegrationTest {
         List<ReservationTime> all = reservationTimeRepository.findAll();
         ReservationTime reservationTime = all.get(0);
 
-        CreateReservationRequest request = ReservationData.getCreateReservationRequestWithId(
+        CreateReservationRequest request = ReservationFixture.getCreateReservationRequestWithId(
             reservationTime.getId());
 
         mockMvc.perform(post("/reservations/success")
@@ -100,7 +100,7 @@ class ReservationControllerTest extends BaseIntegrationTest {
     @Test
     @DisplayName("이미 예약이 된 시간에 대해 예약 등록 api 호출 시 에러 메세지가 반환된다.")
     void registerReservationWithException() throws Exception {
-        ReservationTime reservationTime = ReservationData.getReservationTimeNotPreOccupied();
+        ReservationTime reservationTime = ReservationFixture.getReservationTimeNotPreOccupied();
         reservationTime.reverseOccupied();
         List<Shop> shops = shopRepository.findAll();
         Shop shop = shops.get(0);
@@ -108,7 +108,7 @@ class ReservationControllerTest extends BaseIntegrationTest {
 
         ReservationTime savedReservationTime = reservationTimeRepository.save(reservationTime);
 
-        CreateReservationRequest request = ReservationData.getCreateReservationRequestWithId(
+        CreateReservationRequest request = ReservationFixture.getCreateReservationRequestWithId(
             savedReservationTime.getId());
         mockMvc.perform(post("/reservations/success")
                 .contentType(APPLICATION_JSON)

--- a/src/test/java/com/prgrms/catchtable/reservation/controller/ReservationControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/controller/ReservationControllerTest.java
@@ -32,7 +32,7 @@ class ReservationControllerTest extends BaseIntegrationTest {
     private ShopRepository shopRepository;
 
     @BeforeEach
-    void setUp(){
+    void setUp() {
         Shop shop = ShopData.getShop();
         Shop savedShop = shopRepository.save(shop);
 
@@ -87,8 +87,8 @@ class ReservationControllerTest extends BaseIntegrationTest {
             reservationTime.getId());
 
         mockMvc.perform(post("/reservations/success")
-            .contentType(APPLICATION_JSON)
-            .content(asJsonString(request)))
+                .contentType(APPLICATION_JSON)
+                .content(asJsonString(request)))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.shopName").value(reservationTime.getShop().getName()))
             .andExpect(jsonPath("$.date").value(reservationTime.getTime().toString()))
@@ -108,7 +108,8 @@ class ReservationControllerTest extends BaseIntegrationTest {
 
         ReservationTime savedReservationTime = reservationTimeRepository.save(reservationTime);
 
-        CreateReservationRequest request = ReservationData.getCreateReservationRequestWithId(savedReservationTime.getId());
+        CreateReservationRequest request = ReservationData.getCreateReservationRequestWithId(
+            savedReservationTime.getId());
         mockMvc.perform(post("/reservations/success")
                 .contentType(APPLICATION_JSON)
                 .content(asJsonString(request)))

--- a/src/test/java/com/prgrms/catchtable/reservation/domain/ReservationTimeTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/domain/ReservationTimeTest.java
@@ -2,7 +2,7 @@ package com.prgrms.catchtable.reservation.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.prgrms.catchtable.common.data.reservation.ReservationData;
+import com.prgrms.catchtable.reservation.fixture.ReservationFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -11,7 +11,7 @@ class ReservationTimeTest {
     @Test
     @DisplayName("예약 선점 여부 변경에 성공한다")
     void reversePreOccupied() {
-        ReservationTime reservationTime = ReservationData.getReservationTimeNotPreOccupied();
+        ReservationTime reservationTime = ReservationFixture.getReservationTimeNotPreOccupied();
         reservationTime.reversePreOccupied();
 
         assertThat(reservationTime.isPreOccupied()).isTrue();
@@ -20,7 +20,7 @@ class ReservationTimeTest {
     @Test
     @DisplayName("예약 여부 변경에 성공한다.")
     void reverseOccupied() {
-        ReservationTime reservationTime = ReservationData.getReservationTimeNotPreOccupied();
+        ReservationTime reservationTime = ReservationFixture.getReservationTimeNotPreOccupied();
         reservationTime.reverseOccupied();
 
         assertThat(reservationTime.isOccupied()).isTrue();

--- a/src/test/java/com/prgrms/catchtable/reservation/fixture/ReservationFixture.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/fixture/ReservationFixture.java
@@ -1,4 +1,4 @@
-package com.prgrms.catchtable.common.data.reservation;
+package com.prgrms.catchtable.reservation.fixture;
 
 import static com.prgrms.catchtable.reservation.domain.ReservationStatus.COMPLETED;
 
@@ -10,7 +10,7 @@ import com.prgrms.catchtable.shop.domain.Shop;
 import java.time.LocalDateTime;
 import org.springframework.test.util.ReflectionTestUtils;
 
-public class ReservationData {
+public class ReservationFixture {
 
     public static Reservation getReservation() {
         return Reservation.builder()

--- a/src/test/java/com/prgrms/catchtable/reservation/repository/ReservationTimeRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/repository/ReservationTimeRepositoryTest.java
@@ -3,7 +3,7 @@ package com.prgrms.catchtable.reservation.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.prgrms.catchtable.common.data.reservation.ReservationData;
+import com.prgrms.catchtable.reservation.fixture.ReservationFixture;
 import com.prgrms.catchtable.common.data.shop.ShopData;
 import com.prgrms.catchtable.common.exception.ErrorCode;
 import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
@@ -31,7 +31,7 @@ class ReservationTimeRepositoryTest {
         Shop shop = ShopData.getShop();
         Shop savedShop = shopRepository.save(shop);
 
-        ReservationTime reservationTime = ReservationData.getReservationTimeNotPreOccupied();
+        ReservationTime reservationTime = ReservationFixture.getReservationTimeNotPreOccupied();
         reservationTime.insertShop(savedShop);
         ReservationTime savedTime = reservationTimeRepository.save(reservationTime);
 

--- a/src/test/java/com/prgrms/catchtable/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/service/ReservationServiceTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import com.prgrms.catchtable.common.data.reservation.ReservationData;
+import com.prgrms.catchtable.reservation.fixture.ReservationFixture;
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import com.prgrms.catchtable.reservation.domain.Reservation;
 import com.prgrms.catchtable.reservation.domain.ReservationTime;
@@ -37,9 +37,9 @@ class ReservationServiceTest {
     @DisplayName("예약시간의 선점 여부를 검증하고 선점권이 빈 것을 확인한다.")
     void validateReservation() {
         //given
-        ReservationTime reservationTime = ReservationData.getReservationTimeNotPreOccupied();
+        ReservationTime reservationTime = ReservationFixture.getReservationTimeNotPreOccupied();
         ReflectionTestUtils.setField(reservationTime, "id", 1L);
-        CreateReservationRequest request = ReservationData.getCreateReservationRequestWithId(
+        CreateReservationRequest request = ReservationFixture.getCreateReservationRequestWithId(
             reservationTime.getId());
 
         when(reservationTimeRepository.findById(1L)).thenReturn(Optional.of(reservationTime));
@@ -61,9 +61,9 @@ class ReservationServiceTest {
     @DisplayName("예약시간 선점권이 이미 타인에게 있는 경우 예외가 발생한다.")
     void alreadyPreOccupied() {
         //given
-        ReservationTime reservationTime = ReservationData.getReservationTimePreOccupied();
+        ReservationTime reservationTime = ReservationFixture.getReservationTimePreOccupied();
         ReflectionTestUtils.setField(reservationTime, "id", 1L);
-        CreateReservationRequest request = ReservationData.getCreateReservationRequestWithId(
+        CreateReservationRequest request = ReservationFixture.getCreateReservationRequestWithId(
             reservationTime.getId());
 
         when(reservationTimeRepository.findById(1L)).thenReturn(Optional.of(reservationTime));
@@ -78,8 +78,8 @@ class ReservationServiceTest {
     @Test
     @DisplayName("최종예약을 등록할 때 예약시간이 비었으면 성공적으로 예약 등록을 완료한다.")
     void registerReservation() {
-        ReservationTime reservationTime = ReservationData.getReservationTimePreOccupied();
-        CreateReservationRequest request = ReservationData.getCreateReservationRequest();
+        ReservationTime reservationTime = ReservationFixture.getReservationTimePreOccupied();
+        CreateReservationRequest request = ReservationFixture.getCreateReservationRequest();
         Reservation reservation = Reservation.builder()
             .status(COMPLETED)
             .peopleCount(request.peopleCount())
@@ -103,8 +103,8 @@ class ReservationServiceTest {
     @Test
     @DisplayName("최종예약을 등록할 때 타인이 이미 예약한 경우 예외가 발생한다.")
     void registerReservationAlreadyOccupied() {
-        ReservationTime reservationTime = ReservationData.getReservationTimePreOccupied();
-        CreateReservationRequest request = ReservationData.getCreateReservationRequest();
+        ReservationTime reservationTime = ReservationFixture.getReservationTimePreOccupied();
+        CreateReservationRequest request = ReservationFixture.getCreateReservationRequest();
 
         reservationTime.reverseOccupied();
         when(reservationTimeRepository.findByIdWithShop(any(Long.class))).thenReturn(


### PR DESCRIPTION
close #42 

### ⛏ 작업 상세 내용

- BaseIntegrationTest 클래스에 Transaction 어노테이션 제거 (각자 클래스에서 필요 시 사용하도록)
- 예약 등록 api 구현
- 예약 등록 api 통합테스트
    - 예약 등록 api 정상 호출 테스트
    - 이미 등록된 예약시간에 대해 예약 api 호출시 에러코드 반환 테스트
 - 예약 테스트용 데이터 클래스 네이밍 변경 및 패키지 구조 변경
     - ReservationData -> ReservationFixture

### 📝 작업 요약

- api 구현 및 테스트

### **☑️** 중점적으로 리뷰 할 부분

- 테스트 로직
