### PR TITLE
feat : 예약 선점 로직 동시성 이슈 제어

### DIFF
--- a/src/main/java/com/prgrms/catchtable/reservation/service/ReservationService.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/service/ReservationService.java
@@ -5,6 +5,7 @@ import static com.prgrms.catchtable.common.exception.ErrorCode.ALREADY_PREOCCUPI
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_TIME;
 import static com.prgrms.catchtable.reservation.domain.ReservationStatus.COMPLETED;
 import static com.prgrms.catchtable.reservation.dto.mapper.ReservationMapper.toCreateReservationResponse;
+import static java.lang.Boolean.FALSE;
 
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
@@ -14,6 +15,7 @@ import com.prgrms.catchtable.reservation.dto.mapper.ReservationMapper;
 import com.prgrms.catchtable.reservation.dto.request.CreateReservationRequest;
 import com.prgrms.catchtable.reservation.dto.response.CreateReservationResponse;
 import com.prgrms.catchtable.reservation.dto.response.GetAllReservationResponse;
+import com.prgrms.catchtable.reservation.repository.ReservationLockRepository;
 import com.prgrms.catchtable.reservation.repository.ReservationRepository;
 import com.prgrms.catchtable.reservation.repository.ReservationTimeRepository;
 import com.prgrms.catchtable.shop.domain.Shop;
@@ -29,19 +31,34 @@ public class ReservationService {
     private final ReservationTimeRepository reservationTimeRepository;
     private final ReservationRepository reservationRepository;
     private final ReservationAsync reservationAsync;
+    private final ReservationLockRepository reservationLockRepository;
 
     @Transactional
     public CreateReservationResponse preOccupyReservation(CreateReservationRequest request) {
-        ReservationTime reservationTime = reservationTimeRepository.findById(
-                request.reservationTimeId())
-            .orElseThrow(() -> new NotFoundCustomException(NOT_EXIST_TIME));
+        Long reservationTimeId = request.reservationTimeId();
+        while (FALSE.equals(reservationLockRepository.lock(reservationTimeId))){
+            try {
+                Thread.sleep(1_500);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        ReservationTime reservationTime = reservationTimeRepository.findById(reservationTimeId)
+            .orElseThrow(() -> {
+                    reservationLockRepository.unlock(reservationTimeId);
+                    return new NotFoundCustomException(NOT_EXIST_TIME);
+                }
+            );
 
         if (reservationTime.isPreOccupied()) {
+            reservationLockRepository.unlock(reservationTimeId);
             throw new BadRequestCustomException(ALREADY_PREOCCUPIED_RESERVATION_TIME);
         }
 
         reservationAsync.setPreOcuppied(reservationTime);
+
         Shop shop = reservationTime.getShop();
+        reservationLockRepository.unlock(reservationTimeId);
 
         return CreateReservationResponse.builder()
             .shopName(shop.getName())

--- a/src/test/java/com/prgrms/catchtable/reservation/service/ReservationServiceIntegrationTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/service/ReservationServiceIntegrationTest.java
@@ -1,0 +1,75 @@
+package com.prgrms.catchtable.reservation.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.prgrms.catchtable.common.data.shop.ShopData;
+import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
+import com.prgrms.catchtable.reservation.domain.ReservationTime;
+import com.prgrms.catchtable.reservation.dto.request.CreateReservationRequest;
+import com.prgrms.catchtable.reservation.fixture.ReservationFixture;
+import com.prgrms.catchtable.reservation.repository.ReservationTimeRepository;
+import com.prgrms.catchtable.shop.domain.Shop;
+import com.prgrms.catchtable.shop.repository.ShopRepository;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class ReservationServiceIntegrationTest {
+    @Autowired
+    private ReservationService reservationService;
+    @Autowired
+    private ReservationTimeRepository reservationTimeRepository;
+
+    @Autowired
+    private ShopRepository shopRepository;
+
+    @BeforeEach
+    void setUp() {
+        Shop shop = ShopData.getShop();
+        Shop savedShop = shopRepository.save(shop);
+
+        ReservationTime reservationTime = ReservationFixture.getReservationTimeNotPreOccupied();
+        reservationTime.insertShop(savedShop);
+        reservationTimeRepository.save(reservationTime);
+    }
+    @Test
+    @DisplayName("동시에 요청이 들어오면 하나만 선점권이 true로 바뀌고 나머진 예외가 발생한다.")
+    void concurrencyTest() throws InterruptedException {
+        AtomicInteger errorCount = new AtomicInteger(0);
+
+        List<ReservationTime> all = reservationTimeRepository.findAll();
+        ReservationTime reservationTime = all.get(0);
+
+        CreateReservationRequest request = ReservationFixture.getCreateReservationRequestWithId(
+            reservationTime.getId());
+        int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    reservationService.preOccupyReservation(request);
+                } catch (BadRequestCustomException e) {
+                    errorCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        assertThat(errorCount.get()).isEqualTo(threadCount - 1);
+
+    }
+
+}

--- a/src/test/java/com/prgrms/catchtable/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/service/ReservationServiceTest.java
@@ -1,6 +1,7 @@
 package com.prgrms.catchtable.reservation.service;
 
 import static com.prgrms.catchtable.reservation.domain.ReservationStatus.COMPLETED;
+import static java.lang.Boolean.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -15,6 +16,7 @@ import com.prgrms.catchtable.reservation.dto.request.CreateReservationRequest;
 import com.prgrms.catchtable.reservation.dto.response.CreateReservationResponse;
 import com.prgrms.catchtable.reservation.dto.response.GetAllReservationResponse;
 import com.prgrms.catchtable.reservation.fixture.ReservationFixture;
+import com.prgrms.catchtable.reservation.repository.ReservationLockRepository;
 import com.prgrms.catchtable.reservation.repository.ReservationRepository;
 import com.prgrms.catchtable.reservation.repository.ReservationTimeRepository;
 import java.util.List;
@@ -33,6 +35,8 @@ class ReservationServiceTest {
     @Mock
     private ReservationRepository reservationRepository;
     @Mock
+    private ReservationLockRepository reservationLockRepository;
+    @Mock
     private ReservationAsync reservationAsync;
     @Mock
     private ReservationTimeRepository reservationTimeRepository;
@@ -49,6 +53,8 @@ class ReservationServiceTest {
             reservationTime.getId());
 
         when(reservationTimeRepository.findById(1L)).thenReturn(Optional.of(reservationTime));
+        when(reservationLockRepository.lock(1L)).thenReturn(TRUE);
+        when(reservationLockRepository.unlock(1L)).thenReturn(TRUE);
         doNothing().when(reservationAsync).setPreOcuppied(reservationTime);
         //when
         CreateReservationResponse response = reservationService.preOccupyReservation(
@@ -74,6 +80,7 @@ class ReservationServiceTest {
             reservationTime.getId());
 
         when(reservationTimeRepository.findById(1L)).thenReturn(Optional.of(reservationTime));
+        when(reservationLockRepository.lock(1L)).thenReturn(TRUE);
 
         //when
         assertThrows(BadRequestCustomException.class,
@@ -96,6 +103,7 @@ class ReservationServiceTest {
         when(reservationTimeRepository.findByIdWithShop(any(Long.class))).thenReturn(
             Optional.of(reservationTime));
         when(reservationRepository.save(any(Reservation.class))).thenReturn(reservation);
+
         CreateReservationResponse response = reservationService.registerReservation(request);
 
         assertAll(
@@ -145,7 +153,7 @@ class ReservationServiceTest {
         when(reservationRepository.findAllWithReservationTimeAndShop()).thenReturn(List.of());
 
         List<GetAllReservationResponse> all = reservationService.getAllReservation();
-        assertThat(all.size()).isZero();
+        assertThat(all).isEmpty();
     }
 
 }


### PR DESCRIPTION
close #49 
### ⛏ 작업 상세 내용

- Redis 활용하여 Lock 구현
- 구현한 Lock을 활용해 예약 선점 로직에 동시성 이슈 제어
- 동시요청에 대한 테스트

### 📝 작업 요약

- 예약 선점 로직에 동시성 이슈 제어로직 추가

### **☑️** 중점적으로 리뷰 할 부분

- 예약서비스의 예약 선점 메소드
- 테스트코드
