### PR TITLE
feat : 웨이팅 생성 API Redis queue 사용하도록 수정

### DIFF
--- a/src/main/java/com/prgrms/catchtable/waiting/dto/WaitingMapper.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/dto/WaitingMapper.java
@@ -21,14 +21,14 @@ public class WaitingMapper {
     }
 
     // entity -> dto
-    public static WaitingResponse toCreateWaitingResponse(Waiting waiting, int waitingOrder) {
+    public static WaitingResponse toCreateWaitingResponse(Waiting waiting, Long rank) {
         return WaitingResponse.builder()
             .createdWaitingId(waiting.getId())
             .shopId(waiting.getShop().getId())
             .shopName(waiting.getShop().getName())
             .peopleCount(waiting.getPeopleCount())
             .waitingNumber(waiting.getWaitingNumber())
-            .waitingOrder(waitingOrder)
+            .rank(rank)
             .build();
     }
 }

--- a/src/main/java/com/prgrms/catchtable/waiting/dto/WaitingResponse.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/dto/WaitingResponse.java
@@ -9,7 +9,7 @@ public record WaitingResponse(
     String shopName,
     int peopleCount,
     int waitingNumber,
-    int waitingOrder
+    Long rank
 ) {
 
 }

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/WaitingRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/WaitingRepository.java
@@ -3,7 +3,6 @@ package com.prgrms.catchtable.waiting.repository;
 import com.prgrms.catchtable.member.domain.Member;
 import com.prgrms.catchtable.shop.domain.Shop;
 import com.prgrms.catchtable.waiting.domain.Waiting;
-import com.prgrms.catchtable.waiting.domain.WaitingStatus;
 import java.time.LocalDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/WaitingRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/WaitingRepository.java
@@ -11,8 +11,5 @@ public interface WaitingRepository extends JpaRepository<Waiting, Long> {
 
     boolean existsByMember(Member member);
 
-    Long countByShopAndStatusAndCreatedAtBetween(Shop shop, WaitingStatus status,
-        LocalDateTime start, LocalDateTime end);
-
     Long countByShopAndCreatedAtBetween(Shop shop, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepository.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-public class BasicWaitingLineRepository implements WaitingLineRepository{
+public class BasicWaitingLineRepository implements WaitingLineRepository {
 
     public final Map<Long, Queue<Long>> waitingLines = new ConcurrentHashMap<>();
 
@@ -63,7 +63,7 @@ public class BasicWaitingLineRepository implements WaitingLineRepository{
         int index = 0;
         for (Long waitingIdInLine : waitingLine) {
             if (Objects.equals(waitingIdInLine, waitingId)) {
-                return (long)index + 1;
+                return (long) index + 1;
             }
             index++;
         }

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepository.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.SessionCallback;
@@ -17,8 +18,9 @@ import org.springframework.stereotype.Component;
 
 @Slf4j
 @RequiredArgsConstructor
+@Primary
 @Component
-public class RedisWaitingLineRepository implements WaitingLineRepository{
+public class RedisWaitingLineRepository implements WaitingLineRepository {
 
     private final StringRedisTemplate redisTemplate;
 

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/WaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/WaitingLineRepository.java
@@ -1,11 +1,18 @@
 package com.prgrms.catchtable.waiting.repository.waitingline;
 
 public interface WaitingLineRepository {
+
     void save(Long shopId, Long waitingId);
+
     void entry(Long shopId, Long waitingId);
+
     void cancel(Long shopId, Long waitingId);
+
     void postpone(Long shopId, Long waitingId);
+
     Long findRank(Long shopId, Long waitingId);
+
     Long getWaitingLineSize(Long shopId);
+
     void printWaitingLine(Long shopId);
 }

--- a/src/main/java/com/prgrms/catchtable/waiting/service/WaitingService.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/service/WaitingService.java
@@ -3,6 +3,8 @@ package com.prgrms.catchtable.waiting.service;
 import static com.prgrms.catchtable.common.exception.ErrorCode.EXISTING_MEMBER_WAITING;
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_MEMBER;
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_SHOP;
+import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toCreateWaitingResponse;
+import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toWaiting;
 
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
@@ -12,7 +14,6 @@ import com.prgrms.catchtable.shop.domain.Shop;
 import com.prgrms.catchtable.shop.repository.ShopRepository;
 import com.prgrms.catchtable.waiting.domain.Waiting;
 import com.prgrms.catchtable.waiting.dto.CreateWaitingRequest;
-import com.prgrms.catchtable.waiting.dto.WaitingMapper;
 import com.prgrms.catchtable.waiting.dto.WaitingResponse;
 import com.prgrms.catchtable.waiting.repository.WaitingRepository;
 import com.prgrms.catchtable.waiting.repository.waitingline.WaitingLineRepository;
@@ -52,13 +53,13 @@ public class WaitingService {
             START_DATE_TIME, END_DATE_TIME)).intValue() + 1;
 
         // waiting 저장
-        Waiting waiting = WaitingMapper.toWaiting(request, waitingNumber, member, shop);
+        Waiting waiting = toWaiting(request, waitingNumber, member, shop);
         Waiting savedWaiting = waitingRepository.save(waiting);
 
         waitingLineRepository.save(shopId, waiting.getId());
         Long rank = waitingLineRepository.findRank(shopId, waiting.getId());
 
-        return WaitingMapper.toCreateWaitingResponse(savedWaiting, rank);
+        return toCreateWaitingResponse(savedWaiting, rank);
     }
 
 

--- a/src/main/java/com/prgrms/catchtable/waiting/service/WaitingService.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/service/WaitingService.java
@@ -3,7 +3,6 @@ package com.prgrms.catchtable.waiting.service;
 import static com.prgrms.catchtable.common.exception.ErrorCode.EXISTING_MEMBER_WAITING;
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_MEMBER;
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_SHOP;
-import static com.prgrms.catchtable.waiting.domain.WaitingStatus.PROGRESS;
 
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;

--- a/src/test/java/com/prgrms/catchtable/waiting/controller/WaitingControllerDocsTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/controller/WaitingControllerDocsTest.java
@@ -41,7 +41,7 @@ class WaitingControllerDocsTest extends RestDocsSupport {
             .shopId(1L)
             .shopName("shop1")
             .waitingNumber(324)
-            .waitingOrder(20)
+            .rank(20L)
             .peopleCount(2)
             .build();
 
@@ -69,7 +69,7 @@ class WaitingControllerDocsTest extends RestDocsSupport {
                         .description("인원 수"),
                     fieldWithPath("waitingNumber").type(JsonFieldType.NUMBER)
                         .description("웨이팅 고유 번호"),
-                    fieldWithPath("waitingOrder").type(JsonFieldType.NUMBER)
+                    fieldWithPath("rank").type(JsonFieldType.NUMBER)
                         .description("웨이팅 순서")
                 )
             ));

--- a/src/test/java/com/prgrms/catchtable/waiting/controller/WaitingControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/controller/WaitingControllerTest.java
@@ -50,7 +50,6 @@ class WaitingControllerTest extends BaseIntegrationTest {
     void setUp() {
         shop = ShopFixture.shopWith24();
         shopRepository.save(shop);
-        redisTemplate.delete("s" + shop.getId());
         Member member1 = MemberFixture.member("test1@naver.com");
         Member member2 = MemberFixture.member("test2@naver.com");
         member3 = MemberFixture.member("test3@naver.com");

--- a/src/test/java/com/prgrms/catchtable/waiting/controller/WaitingControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/controller/WaitingControllerTest.java
@@ -17,8 +17,8 @@ import com.prgrms.catchtable.waiting.dto.CreateWaitingRequest;
 import com.prgrms.catchtable.waiting.repository.WaitingRepository;
 import com.prgrms.catchtable.waiting.repository.waitingline.WaitingLineRepository;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,7 +27,6 @@ import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
-@Disabled
 class WaitingControllerTest extends BaseIntegrationTest {
 
     @Autowired
@@ -49,10 +48,9 @@ class WaitingControllerTest extends BaseIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        redisTemplate.delete("s1");
-
         shop = ShopFixture.shopWith24();
         shopRepository.save(shop);
+        redisTemplate.delete("s" + shop.getId());
         Member member1 = MemberFixture.member("test1@naver.com");
         Member member2 = MemberFixture.member("test2@naver.com");
         member3 = MemberFixture.member("test3@naver.com");
@@ -76,6 +74,10 @@ class WaitingControllerTest extends BaseIntegrationTest {
         waitingLineRepository.save(shop.getId(), waiting2.getId());
     }
 
+    @AfterEach
+    void clear() {
+        redisTemplate.delete("s" + shop.getId());
+    }
 
     @DisplayName("웨이팅 생성 API를 호출할 수 있다.")
     @Test

--- a/src/test/java/com/prgrms/catchtable/waiting/repository/WaitingRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/repository/WaitingRepositoryTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -78,24 +80,5 @@ class WaitingRepositoryTest {
             END_DATE_TIME);
         //then
         assertThat(count).isEqualTo(2L); //waiting2, waiting3
-    }
-
-    @DisplayName("특정 가게의 당일 대기 순서를 조회할 수 있다.")
-    @Test
-    void countByShopAndStatusAndCreatedAtBetween() {
-        yesterdayWaiting = WaitingFixture.waiting(member1, shop, 1);
-        completedWaiting = WaitingFixture.completedWaiting(member2, shop, 2);
-        normalWaiting = WaitingFixture.waiting(member3, shop, 3);
-        waitingRepository.saveAll(List.of(yesterdayWaiting, completedWaiting, normalWaiting));
-
-        ReflectionTestUtils.setField(yesterdayWaiting, "createdAt",
-            LocalDateTime.now().minusDays(1));
-        waitingRepository.save(yesterdayWaiting);
-
-        //when
-        Long count = waitingRepository.countByShopAndStatusAndCreatedAtBetween(shop, PROGRESS,
-            START_DATE_TIME, END_DATE_TIME);
-        //then
-        assertThat(count).isEqualTo(1L); //waiting3
     }
 }

--- a/src/test/java/com/prgrms/catchtable/waiting/repository/WaitingRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/repository/WaitingRepositoryTest.java
@@ -1,6 +1,5 @@
 package com.prgrms.catchtable.waiting.repository;
 
-import static com.prgrms.catchtable.waiting.domain.WaitingStatus.PROGRESS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.prgrms.catchtable.member.MemberFixture;
@@ -21,8 +20,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepositoryTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class BasicWaitingLineRepositoryTest{
+class BasicWaitingLineRepositoryTest {
 
     private final BasicWaitingLineRepository repository = new BasicWaitingLineRepository();
 

--- a/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepositoryTest.java
@@ -106,7 +106,6 @@ class RedisWaitingLineRepositoryTest {
     void cancel() {
         //given
         Long shopId = 1L;
-        repository.printWaitingLine(1L);
         repository.save(shopId, 1L);
         repository.save(shopId, 2L);
         repository.save(shopId, 3L);

--- a/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepositoryTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepositoryTest.java
@@ -5,8 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
-import com.prgrms.catchtable.waiting.repository.waitingline.RedisWaitingLineRepository;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,12 +22,9 @@ class RedisWaitingLineRepositoryTest {
     @Autowired
     private StringRedisTemplate redisTemplate;
 
-
     @AfterEach
     void clear() {
         redisTemplate.delete("s1");
-        redisTemplate.delete("s2");
-        redisTemplate.delete("s3");
     }
 
     @DisplayName("큐에 웨이팅을 추가한 후 순서를 반환받을 수 있다.")
@@ -110,11 +107,10 @@ class RedisWaitingLineRepositoryTest {
     void cancel() {
         //given
         Long shopId = 1L;
-
+        repository.printWaitingLine(1L);
         repository.save(shopId, 1L);
         repository.save(shopId, 2L);
         repository.save(shopId, 3L);
-
         //when
         repository.cancel(1L, 1L);
         //then

--- a/src/test/java/com/prgrms/catchtable/waiting/service/WaitingServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/service/WaitingServiceTest.java
@@ -15,6 +15,7 @@ import com.prgrms.catchtable.waiting.domain.Waiting;
 import com.prgrms.catchtable.waiting.dto.CreateWaitingRequest;
 import com.prgrms.catchtable.waiting.dto.WaitingResponse;
 import com.prgrms.catchtable.waiting.repository.WaitingRepository;
+import com.prgrms.catchtable.waiting.repository.waitingline.WaitingLineRepository;
 import java.time.LocalTime;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -32,6 +33,9 @@ class WaitingServiceTest {
     private ShopRepository shopRepository;
     @Mock
     private MemberRepository memberRepository;
+
+    @Mock
+    private WaitingLineRepository waitingLineRepository;
     @InjectMocks
     private WaitingService waitingService;
 
@@ -51,16 +55,19 @@ class WaitingServiceTest {
             .build();
         doNothing().when(shop).validateIfShopOpened(any(LocalTime.class));
         given(shopRepository.findById(1L)).willReturn(Optional.of(shop));
-        given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
+        given(shop.getId()).willReturn(1L);
+
+        given(memberRepository.findById(1L)).willReturn(Optional.of(member));
         given(waitingRepository.existsByMember(member)).willReturn(false);
         given(waitingRepository.save(any(Waiting.class))).willReturn(waiting);
+        given(waitingLineRepository.findRank(shop.getId(), waiting.getId())).willReturn(1L);
 
         //when
-        WaitingResponse response = waitingService.createWaiting(1L, member.getId(), request);
+        WaitingResponse response = waitingService.createWaiting(1L, 1L, request);
         //then
         assertAll(
             () -> assertThat(response.peopleCount()).isEqualTo(2),
-            () -> assertThat(response.waitingOrder()).isEqualTo(1),
+            () -> assertThat(response.rank()).isEqualTo(1L),
             () -> assertThat(response.waitingNumber()).isEqualTo(1)
         );
     }


### PR DESCRIPTION
### ⛏ 작업 상세 내용

- waitingOrder 필드 변경
  - Long 타입으로 변경 (redis 반환 타입)
  - waitingOrder -> rank로 필드명 및 응답 스펙 수정
- repository rank 조회 함수 삭제
   - rank repository가 아닌 queue에서 조회
 - service 로직 변경
   - 기존 테스트 코드들 수정

### 📝 작업 요약

- 서비스 로직 수정

### **☑️** 중점적으로 리뷰 할 부분
- rank가 Long 타입이니 waitingNumber도 Long 타입으로 통일할지

