### PR TITLE
feat : Owner의 예약 노쇼, 취소처리 / 예약 전체조회 API 구현

### DIFF
--- a/src/main/java/com/prgrms/catchtable/common/exception/ErrorCode.java
+++ b/src/main/java/com/prgrms/catchtable/common/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     NOT_EXIST_TIME("존재하지 않는 예약 시간입니다."),
     NOT_EXIST_RESERVATION("존재하지 않는 예약입니다"),
     EXCEED_PEOPLE_COUNT("예약인원이 해당 시간의 남은 수용가능 인원 수를 초과했습니다."),
+    ALREADY_COMPLETED("이미 예약 상태인 예약입니다."),
 
     CAN_NOT_COMPLETE_WAITING("입장 처리가 불가한 대기 상태입니다."),
     EXISTING_MEMBER_WAITING("이미 회원이 웨이팅 중인 가게가 존재합니다."),

--- a/src/main/java/com/prgrms/catchtable/common/exception/ErrorCode.java
+++ b/src/main/java/com/prgrms/catchtable/common/exception/ErrorCode.java
@@ -16,7 +16,7 @@ public enum ErrorCode {
     NOT_EXIST_TIME("존재하지 않는 예약 시간입니다."),
     NOT_EXIST_RESERVATION("존재하지 않는 예약입니다"),
     EXCEED_PEOPLE_COUNT("예약인원이 해당 시간의 남은 수용가능 인원 수를 초과했습니다."),
-    ALREADY_COMPLETED("이미 예약 상태인 예약입니다."),
+    ALREADY_COMPLETED_RESERVATION("이미 예약 상태인 예약입니다."),
 
     CAN_NOT_COMPLETE_WAITING("입장 처리가 불가한 대기 상태입니다."),
     EXISTING_MEMBER_WAITING("이미 회원이 웨이팅 중인 가게가 존재합니다."),

--- a/src/main/java/com/prgrms/catchtable/owner/domain/Owner.java
+++ b/src/main/java/com/prgrms/catchtable/owner/domain/Owner.java
@@ -57,7 +57,7 @@ public class Owner extends BaseEntity {
         this.dateBirth = dateBirth;
     }
 
-    public void insertShop(Shop shop){
+    public void insertShop(Shop shop) {
         this.shop = shop;
     }
 }

--- a/src/main/java/com/prgrms/catchtable/owner/domain/Owner.java
+++ b/src/main/java/com/prgrms/catchtable/owner/domain/Owner.java
@@ -56,4 +56,8 @@ public class Owner extends BaseEntity {
         this.gender = gender;
         this.dateBirth = dateBirth;
     }
+
+    public void insertShop(Shop shop){
+        this.shop = shop;
+    }
 }

--- a/src/main/java/com/prgrms/catchtable/reservation/controller/MemberReservationController.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/controller/MemberReservationController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/reservations")
 @RequiredArgsConstructor
-public class ReservationController {
+public class MemberReservationController {
 
     private final MemberReservationService memberReservationService;
 

--- a/src/main/java/com/prgrms/catchtable/reservation/controller/MemberReservationController.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/controller/MemberReservationController.java
@@ -44,7 +44,8 @@ public class MemberReservationController {
     }
 
     @DeleteMapping("/{reservationId}")
-    public ResponseEntity<CancelReservationResponse> cancelReservation(@PathVariable("reservationId") Long reservationId){
+    public ResponseEntity<CancelReservationResponse> cancelReservation(
+        @PathVariable("reservationId") Long reservationId) {
         return ResponseEntity.ok(memberReservationService.cancelReservation(reservationId));
     }
 }

--- a/src/main/java/com/prgrms/catchtable/reservation/controller/OwnerReservationController.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/controller/OwnerReservationController.java
@@ -1,6 +1,5 @@
 package com.prgrms.catchtable.reservation.controller;
 
-import com.prgrms.catchtable.owner.domain.Owner;
 import com.prgrms.catchtable.reservation.dto.request.ModifyReservationStatusRequest;
 import com.prgrms.catchtable.reservation.dto.response.OwnerGetAllReservationResponse;
 import com.prgrms.catchtable.reservation.service.OwnerReservationService;
@@ -18,18 +17,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/owners/shop")
 @RequiredArgsConstructor
 public class OwnerReservationController {
+
     private final OwnerReservationService ownerReservationService;
 
     @PostMapping("/{reservationId}")
     public void modifyReservationStatus(
         @PathVariable("reservationId") Long reservationId,
         @RequestBody ModifyReservationStatusRequest request
-    ){
+    ) {
         ownerReservationService.modifyReservationStatus(reservationId, request);
     }
 
     @GetMapping
-    public ResponseEntity<List<OwnerGetAllReservationResponse>> getAllReservation(@RequestBody Long ownerId){
+    public ResponseEntity<List<OwnerGetAllReservationResponse>> getAllReservation(
+        @RequestBody Long ownerId) {
         return ResponseEntity.ok(ownerReservationService.getAllReservation(ownerId));
     }
 }

--- a/src/main/java/com/prgrms/catchtable/reservation/controller/OwnerReservationController.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/controller/OwnerReservationController.java
@@ -1,0 +1,35 @@
+package com.prgrms.catchtable.reservation.controller;
+
+import com.prgrms.catchtable.owner.domain.Owner;
+import com.prgrms.catchtable.reservation.dto.request.ModifyReservationStatusRequest;
+import com.prgrms.catchtable.reservation.dto.response.OwnerGetAllReservationResponse;
+import com.prgrms.catchtable.reservation.service.OwnerReservationService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/owners/shop")
+@RequiredArgsConstructor
+public class OwnerReservationController {
+    private final OwnerReservationService ownerReservationService;
+
+    @PostMapping("/{reservationId}")
+    public void modifyReservationStatus(
+        @PathVariable("reservationId") Long reservationId,
+        @RequestBody ModifyReservationStatusRequest request
+    ){
+        ownerReservationService.modifyReservationStatus(reservationId, request);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<OwnerGetAllReservationResponse>> getAllReservation(@RequestBody Long ownerId){
+        return ResponseEntity.ok(ownerReservationService.getAllReservation(ownerId));
+    }
+}

--- a/src/main/java/com/prgrms/catchtable/reservation/controller/ReservationController.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/controller/ReservationController.java
@@ -5,7 +5,7 @@ import com.prgrms.catchtable.reservation.dto.request.ModifyReservationRequest;
 import com.prgrms.catchtable.reservation.dto.response.CancelReservationResponse;
 import com.prgrms.catchtable.reservation.dto.response.CreateReservationResponse;
 import com.prgrms.catchtable.reservation.dto.response.ModifyReservationResponse;
-import com.prgrms.catchtable.reservation.service.ReservationService;
+import com.prgrms.catchtable.reservation.service.MemberReservationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -21,29 +21,30 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ReservationController {
 
-    private final ReservationService reservationService;
+    private final MemberReservationService memberReservationService;
 
     @PostMapping
     public ResponseEntity<CreateReservationResponse> preOccupyReservation(
         @RequestBody CreateReservationRequest request) {
-        return ResponseEntity.ok(reservationService.preOccupyReservation(request));
+        return ResponseEntity.ok(memberReservationService.preOccupyReservation(request));
     }
 
     @PostMapping("/success")
     public ResponseEntity<CreateReservationResponse> registerReservation(
         @RequestBody CreateReservationRequest request) {
-        return ResponseEntity.ok(reservationService.registerReservation(request));
+        return ResponseEntity.ok(memberReservationService.registerReservation(request));
     }
 
     @PatchMapping("/{reservationId}")
     public ResponseEntity<ModifyReservationResponse> modifyReservation(
         @PathVariable("reservationId") Long reservationTimeId,
         @RequestBody ModifyReservationRequest request) {
-        return ResponseEntity.ok(reservationService.modifyReservation(reservationTimeId, request));
+        return ResponseEntity.ok(
+            memberReservationService.modifyReservation(reservationTimeId, request));
     }
 
     @DeleteMapping("/{reservationId}")
     public ResponseEntity<CancelReservationResponse> cancelReservation(@PathVariable("reservationId") Long reservationId){
-        return ResponseEntity.ok(reservationService.cancelReservation(reservationId));
+        return ResponseEntity.ok(memberReservationService.cancelReservation(reservationId));
     }
 }

--- a/src/main/java/com/prgrms/catchtable/reservation/domain/Reservation.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/domain/Reservation.java
@@ -65,7 +65,7 @@ public class Reservation extends BaseEntity {
         this.peopleCount = peopleCount;
     }
 
-    public void changeStatus(ReservationStatus status){
+    public void changeStatus(ReservationStatus status) {
         this.status = status;
     }
 

--- a/src/main/java/com/prgrms/catchtable/reservation/dto/mapper/ReservationMapper.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/dto/mapper/ReservationMapper.java
@@ -7,6 +7,7 @@ import com.prgrms.catchtable.reservation.dto.response.CancelReservationResponse;
 import com.prgrms.catchtable.reservation.dto.response.CreateReservationResponse;
 import com.prgrms.catchtable.reservation.dto.response.GetAllReservationResponse;
 import com.prgrms.catchtable.reservation.dto.response.ModifyReservationResponse;
+import com.prgrms.catchtable.reservation.dto.response.OwnerGetAllReservationResponse;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = PRIVATE)
@@ -42,6 +43,15 @@ public class ReservationMapper {
 
     public static CancelReservationResponse toCancelReservationResponse (Reservation reservation){
         return CancelReservationResponse.builder()
+            .status(reservation.getStatus())
+            .build();
+    }
+
+    public static OwnerGetAllReservationResponse toOwnerGetAllReservationResponse(Reservation reservation){
+        return OwnerGetAllReservationResponse.builder()
+            .reservationId(reservation.getId())
+            .date(reservation.getReservationTime().getTime())
+            .peopleCount(reservation.getPeopleCount())
             .status(reservation.getStatus())
             .build();
     }

--- a/src/main/java/com/prgrms/catchtable/reservation/dto/mapper/ReservationMapper.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/dto/mapper/ReservationMapper.java
@@ -41,13 +41,14 @@ public class ReservationMapper {
             .build();
     }
 
-    public static CancelReservationResponse toCancelReservationResponse (Reservation reservation){
+    public static CancelReservationResponse toCancelReservationResponse(Reservation reservation) {
         return CancelReservationResponse.builder()
             .status(reservation.getStatus())
             .build();
     }
 
-    public static OwnerGetAllReservationResponse toOwnerGetAllReservationResponse(Reservation reservation){
+    public static OwnerGetAllReservationResponse toOwnerGetAllReservationResponse(
+        Reservation reservation) {
         return OwnerGetAllReservationResponse.builder()
             .reservationId(reservation.getId())
             .date(reservation.getReservationTime().getTime())

--- a/src/main/java/com/prgrms/catchtable/reservation/dto/request/ModifyReservationStatusRequest.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/dto/request/ModifyReservationStatusRequest.java
@@ -1,0 +1,9 @@
+package com.prgrms.catchtable.reservation.dto.request;
+
+import com.prgrms.catchtable.reservation.domain.ReservationStatus;
+import lombok.Builder;
+
+@Builder
+public record ModifyReservationStatusRequest(ReservationStatus status) {
+
+}

--- a/src/main/java/com/prgrms/catchtable/reservation/dto/response/OwnerGetAllReservationResponse.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/dto/response/OwnerGetAllReservationResponse.java
@@ -1,0 +1,16 @@
+package com.prgrms.catchtable.reservation.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
+import com.prgrms.catchtable.reservation.domain.ReservationStatus;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record OwnerGetAllReservationResponse(Long reservationId,
+                                             @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm")
+                                             LocalDateTime date,
+                                             int peopleCount,
+                                             ReservationStatus status) {
+
+}

--- a/src/main/java/com/prgrms/catchtable/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/repository/ReservationRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
@@ -15,6 +16,12 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     @Query("select r from Reservation r "
         + "join fetch r.reservationTime rt "
-        + "join fetch rt.shop")
-    Optional<Reservation> findByIdWithReservationTimeAndShop(Long reservationId);
+        + "join fetch rt.shop "
+        + "where r.id = :reservationId")
+    Optional<Reservation> findByIdWithReservationTimeAndShop(@Param("reservationId") Long reservationId);
+    @Query("select r from Reservation r "
+        + "join fetch r.reservationTime rt "
+        + "join fetch rt.shop s "
+        + "where s.id = :shopId")
+    List<Reservation> findAllWithReservationTimeAndShopByShopId(@Param("shopId") Long shopId);
 }

--- a/src/main/java/com/prgrms/catchtable/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/repository/ReservationRepository.java
@@ -18,7 +18,9 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
         + "join fetch r.reservationTime rt "
         + "join fetch rt.shop "
         + "where r.id = :reservationId")
-    Optional<Reservation> findByIdWithReservationTimeAndShop(@Param("reservationId") Long reservationId);
+    Optional<Reservation> findByIdWithReservationTimeAndShop(
+        @Param("reservationId") Long reservationId);
+
     @Query("select r from Reservation r "
         + "join fetch r.reservationTime rt "
         + "join fetch rt.shop s "

--- a/src/main/java/com/prgrms/catchtable/reservation/service/MemberReservationService.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/service/MemberReservationService.java
@@ -33,7 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class ReservationService {
+public class MemberReservationService {
 
     private final ReservationTimeRepository reservationTimeRepository;
     private final ReservationRepository reservationRepository;

--- a/src/main/java/com/prgrms/catchtable/reservation/service/MemberReservationService.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/service/MemberReservationService.java
@@ -122,8 +122,9 @@ public class MemberReservationService {
     }
 
     @Transactional
-    public CancelReservationResponse cancelReservation(Long reservationId){
-        Reservation reservation = reservationRepository.findByIdWithReservationTimeAndShop(reservationId)
+    public CancelReservationResponse cancelReservation(Long reservationId) {
+        Reservation reservation = reservationRepository.findByIdWithReservationTimeAndShop(
+                reservationId)
             .orElseThrow(() -> new NotFoundCustomException(NOT_EXIST_RESERVATION));
 
         reservation.changeStatus(CANCELLED); // 해당 예약 상태 취소로 변경

--- a/src/main/java/com/prgrms/catchtable/reservation/service/OwnerReservationService.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/service/OwnerReservationService.java
@@ -1,7 +1,10 @@
 package com.prgrms.catchtable.reservation.service;
 
+import static com.prgrms.catchtable.common.exception.ErrorCode.ALREADY_COMPLETED;
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_RESERVATION;
+import static com.prgrms.catchtable.reservation.domain.ReservationStatus.*;
 
+import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
 import com.prgrms.catchtable.owner.domain.Owner;
 import com.prgrms.catchtable.owner.repository.OwnerRepository;
@@ -9,7 +12,6 @@ import com.prgrms.catchtable.reservation.domain.Reservation;
 import com.prgrms.catchtable.reservation.domain.ReservationStatus;
 import com.prgrms.catchtable.reservation.dto.mapper.ReservationMapper;
 import com.prgrms.catchtable.reservation.dto.request.ModifyReservationStatusRequest;
-import com.prgrms.catchtable.reservation.dto.response.GetAllReservationResponse;
 import com.prgrms.catchtable.reservation.dto.response.OwnerGetAllReservationResponse;
 import com.prgrms.catchtable.reservation.repository.ReservationRepository;
 import com.prgrms.catchtable.reservation.repository.ReservationTimeRepository;
@@ -22,12 +24,12 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class OwnerReservationService {
 
-    private final ReservationTimeRepository reservationTimeRepository;
     private final ReservationRepository reservationRepository;
     private final OwnerRepository ownerRepository;
 
     /**
      * 예약 취소, 노쇼 처리
+     *
      * @param reservationId
      * @param request
      */
@@ -36,25 +38,31 @@ public class OwnerReservationService {
         Long reservationId,
         ModifyReservationStatusRequest request
     ) {
-        ReservationStatus modifyStatus = request.status();
+        ReservationStatus modifyStatus = request.status(); // 요청으로 들어온 변경하려는 예약상태 추출
+
+        if(modifyStatus == COMPLETED){ // 취소, 노쇼 처리가 아닌 경우 예외
+            throw new BadRequestCustomException(ALREADY_COMPLETED);
+        }
 
         Reservation reservation = reservationRepository
             .findByIdWithReservationTimeAndShop(reservationId)
             .orElseThrow(() -> new NotFoundCustomException(NOT_EXIST_RESERVATION));
 
-        reservation.changeStatus(modifyStatus);
+        reservation.changeStatus(modifyStatus); // 해당 예약의 상태를 요청으로 들어온 상태로 변경
 
-        reservation.getReservationTime().reverseOccupied();
+        reservation.getReservationTime().reverseOccupied(); // 해당 예약의 예약시간을 빈 상태로 변경
     }
 
     /**
      * owner가 자신의 가게에 등록된 예약 전체 조회
+     *
      * @return
      */
     @Transactional(readOnly = true)
-    public List<OwnerGetAllReservationResponse> getAllReservation(Long ownerId){
+    public List<OwnerGetAllReservationResponse> getAllReservation(Long ownerId) {
         Owner owner = ownerRepository.findById(ownerId).orElseThrow();
-        List<Reservation> reservations = reservationRepository.findAllWithReservationTimeAndShopByShopId(owner.getShop().getId());
+        List<Reservation> reservations = reservationRepository.findAllWithReservationTimeAndShopByShopId(
+            owner.getShop().getId());
 
         return reservations.stream()
             .map(ReservationMapper::toOwnerGetAllReservationResponse).toList();

--- a/src/main/java/com/prgrms/catchtable/reservation/service/OwnerReservationService.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/service/OwnerReservationService.java
@@ -1,11 +1,8 @@
 package com.prgrms.catchtable.reservation.service;
 
 
-import static com.prgrms.catchtable.common.exception.ErrorCode.ALREADY_COMPLETED;
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_RESERVATION;
-import static com.prgrms.catchtable.reservation.domain.ReservationStatus.COMPLETED;
 
-import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
 import com.prgrms.catchtable.owner.domain.Owner;
 import com.prgrms.catchtable.owner.repository.OwnerRepository;
@@ -40,9 +37,9 @@ public class OwnerReservationService {
     ) {
         ReservationStatus modifyStatus = request.status(); // 요청으로 들어온 변경하려는 예약상태 추출
 
-        if(modifyStatus == COMPLETED){ // 취소, 노쇼 처리가 아닌 경우 예외
-            throw new BadRequestCustomException(ALREADY_COMPLETED);
-        }
+//        if(modifyStatus == COMPLETED){ // 취소, 노쇼 처리가 아닌 경우 예외
+//            throw new BadRequestCustomException(ALREADY_COMPLETED);
+//        }
 
         Reservation reservation = reservationRepository
             .findByIdWithReservationTimeAndShop(reservationId)

--- a/src/main/java/com/prgrms/catchtable/reservation/service/OwnerReservationService.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/service/OwnerReservationService.java
@@ -1,8 +1,9 @@
 package com.prgrms.catchtable.reservation.service;
 
+
 import static com.prgrms.catchtable.common.exception.ErrorCode.ALREADY_COMPLETED;
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_RESERVATION;
-import static com.prgrms.catchtable.reservation.domain.ReservationStatus.*;
+import static com.prgrms.catchtable.reservation.domain.ReservationStatus.COMPLETED;
 
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
@@ -14,7 +15,6 @@ import com.prgrms.catchtable.reservation.dto.mapper.ReservationMapper;
 import com.prgrms.catchtable.reservation.dto.request.ModifyReservationStatusRequest;
 import com.prgrms.catchtable.reservation.dto.response.OwnerGetAllReservationResponse;
 import com.prgrms.catchtable.reservation.repository.ReservationRepository;
-import com.prgrms.catchtable.reservation.repository.ReservationTimeRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/prgrms/catchtable/reservation/service/OwnerReservationService.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/service/OwnerReservationService.java
@@ -1,8 +1,11 @@
 package com.prgrms.catchtable.reservation.service;
 
 
+import static com.prgrms.catchtable.common.exception.ErrorCode.ALREADY_COMPLETED;
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_RESERVATION;
+import static com.prgrms.catchtable.reservation.domain.ReservationStatus.COMPLETED;
 
+import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
 import com.prgrms.catchtable.owner.domain.Owner;
 import com.prgrms.catchtable.owner.repository.OwnerRepository;
@@ -37,9 +40,9 @@ public class OwnerReservationService {
     ) {
         ReservationStatus modifyStatus = request.status(); // 요청으로 들어온 변경하려는 예약상태 추출
 
-//        if(modifyStatus == COMPLETED){ // 취소, 노쇼 처리가 아닌 경우 예외
-//            throw new BadRequestCustomException(ALREADY_COMPLETED);
-//        }
+        if(modifyStatus == COMPLETED){ // 취소, 노쇼 처리가 아닌 경우 예외
+            throw new BadRequestCustomException(ALREADY_COMPLETED);
+        }
 
         Reservation reservation = reservationRepository
             .findByIdWithReservationTimeAndShop(reservationId)

--- a/src/main/java/com/prgrms/catchtable/reservation/service/OwnerReservationService.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/service/OwnerReservationService.java
@@ -1,7 +1,7 @@
 package com.prgrms.catchtable.reservation.service;
 
 
-import static com.prgrms.catchtable.common.exception.ErrorCode.ALREADY_COMPLETED;
+import static com.prgrms.catchtable.common.exception.ErrorCode.ALREADY_COMPLETED_RESERVATION;
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_RESERVATION;
 import static com.prgrms.catchtable.reservation.domain.ReservationStatus.COMPLETED;
 
@@ -41,7 +41,7 @@ public class OwnerReservationService {
         ReservationStatus modifyStatus = request.status(); // 요청으로 들어온 변경하려는 예약상태 추출
 
         if(modifyStatus == COMPLETED){ // 취소, 노쇼 처리가 아닌 경우 예외
-            throw new BadRequestCustomException(ALREADY_COMPLETED);
+            throw new BadRequestCustomException(ALREADY_COMPLETED_RESERVATION);
         }
 
         Reservation reservation = reservationRepository

--- a/src/main/java/com/prgrms/catchtable/reservation/service/OwnerReservationService.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/service/OwnerReservationService.java
@@ -1,0 +1,62 @@
+package com.prgrms.catchtable.reservation.service;
+
+import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_RESERVATION;
+
+import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
+import com.prgrms.catchtable.owner.domain.Owner;
+import com.prgrms.catchtable.owner.repository.OwnerRepository;
+import com.prgrms.catchtable.reservation.domain.Reservation;
+import com.prgrms.catchtable.reservation.domain.ReservationStatus;
+import com.prgrms.catchtable.reservation.dto.mapper.ReservationMapper;
+import com.prgrms.catchtable.reservation.dto.request.ModifyReservationStatusRequest;
+import com.prgrms.catchtable.reservation.dto.response.GetAllReservationResponse;
+import com.prgrms.catchtable.reservation.dto.response.OwnerGetAllReservationResponse;
+import com.prgrms.catchtable.reservation.repository.ReservationRepository;
+import com.prgrms.catchtable.reservation.repository.ReservationTimeRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OwnerReservationService {
+
+    private final ReservationTimeRepository reservationTimeRepository;
+    private final ReservationRepository reservationRepository;
+    private final OwnerRepository ownerRepository;
+
+    /**
+     * 예약 취소, 노쇼 처리
+     * @param reservationId
+     * @param request
+     */
+    @Transactional
+    public void modifyReservationStatus(
+        Long reservationId,
+        ModifyReservationStatusRequest request
+    ) {
+        ReservationStatus modifyStatus = request.status();
+
+        Reservation reservation = reservationRepository
+            .findByIdWithReservationTimeAndShop(reservationId)
+            .orElseThrow(() -> new NotFoundCustomException(NOT_EXIST_RESERVATION));
+
+        reservation.changeStatus(modifyStatus);
+
+        reservation.getReservationTime().reverseOccupied();
+    }
+
+    /**
+     * owner가 자신의 가게에 등록된 예약 전체 조회
+     * @return
+     */
+    @Transactional(readOnly = true)
+    public List<OwnerGetAllReservationResponse> getAllReservation(Long ownerId){
+        Owner owner = ownerRepository.findById(ownerId).orElseThrow();
+        List<Reservation> reservations = reservationRepository.findAllWithReservationTimeAndShopByShopId(owner.getShop().getId());
+
+        return reservations.stream()
+            .map(ReservationMapper::toOwnerGetAllReservationResponse).toList();
+    }
+}

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepository.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-public class BasicWaitingLineRepository implements WaitingLineRepository{
+public class BasicWaitingLineRepository implements WaitingLineRepository {
 
     public final Map<Long, Queue<Long>> waitingLines = new ConcurrentHashMap<>();
 
@@ -63,7 +63,7 @@ public class BasicWaitingLineRepository implements WaitingLineRepository{
         int index = 0;
         for (Long waitingIdInLine : waitingLine) {
             if (Objects.equals(waitingIdInLine, waitingId)) {
-                return (long)index + 1;
+                return (long) index + 1;
             }
             index++;
         }

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepository.java
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @RequiredArgsConstructor
 @Component
-public class RedisWaitingLineRepository implements WaitingLineRepository{
+public class RedisWaitingLineRepository implements WaitingLineRepository {
 
     private final StringRedisTemplate redisTemplate;
 

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/WaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/WaitingLineRepository.java
@@ -1,11 +1,18 @@
 package com.prgrms.catchtable.waiting.repository.waitingline;
 
 public interface WaitingLineRepository {
+
     void save(Long shopId, Long waitingId);
+
     void entry(Long shopId, Long waitingId);
+
     void cancel(Long shopId, Long waitingId);
+
     void postpone(Long shopId, Long waitingId);
+
     Long findRank(Long shopId, Long waitingId);
+
     Long getWaitingLineSize(Long shopId);
+
     void printWaitingLine(Long shopId);
 }

--- a/src/test/java/com/prgrms/catchtable/owner/fixture/OwnerFixture.java
+++ b/src/test/java/com/prgrms/catchtable/owner/fixture/OwnerFixture.java
@@ -1,9 +1,8 @@
 package com.prgrms.catchtable.owner.fixture;
 
-import static com.prgrms.catchtable.member.domain.Gender.*;
+import static com.prgrms.catchtable.member.domain.Gender.MALE;
 
 import com.prgrms.catchtable.common.data.shop.ShopData;
-import com.prgrms.catchtable.member.domain.Gender;
 import com.prgrms.catchtable.owner.domain.Owner;
 import com.prgrms.catchtable.shop.domain.Shop;
 import java.time.LocalDate;
@@ -11,7 +10,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 public class OwnerFixture {
 
-    public static Owner getOwner(){
+    public static Owner getOwner() {
         Owner owner = Owner.builder()
             .name("ownerA")
             .phoneNumber("010-3462-2480")

--- a/src/test/java/com/prgrms/catchtable/owner/fixture/OwnerFixture.java
+++ b/src/test/java/com/prgrms/catchtable/owner/fixture/OwnerFixture.java
@@ -1,0 +1,27 @@
+package com.prgrms.catchtable.owner.fixture;
+
+import static com.prgrms.catchtable.member.domain.Gender.*;
+
+import com.prgrms.catchtable.common.data.shop.ShopData;
+import com.prgrms.catchtable.member.domain.Gender;
+import com.prgrms.catchtable.owner.domain.Owner;
+import com.prgrms.catchtable.shop.domain.Shop;
+import java.time.LocalDate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class OwnerFixture {
+
+    public static Owner getOwner(){
+        Owner owner = Owner.builder()
+            .name("ownerA")
+            .phoneNumber("010-3462-2480")
+            .gender(MALE)
+            .dateBirth(LocalDate.of(2000, 9, 13))
+            .build();
+        Shop shop = ShopData.getShop();
+        ReflectionTestUtils.setField(shop, "id", 1L);
+        owner.insertShop(shop);
+        return owner;
+    }
+
+}

--- a/src/test/java/com/prgrms/catchtable/reservation/controller/MemberReservationControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/controller/MemberReservationControllerTest.java
@@ -30,7 +30,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
-class ReservationControllerTest extends BaseIntegrationTest {
+class MemberReservationControllerTest extends BaseIntegrationTest {
 
     @Autowired
     private ReservationTimeRepository reservationTimeRepository;
@@ -133,9 +133,16 @@ class ReservationControllerTest extends BaseIntegrationTest {
         ReservationTime reservationTime = reservationTimeRepository.findAll().get(0);
         Reservation reservation = ReservationFixture.getReservation(reservationTime);
         Reservation savedReservation = reservationRepository.save(reservation);
+        /**
+         * 수정하려는 예약시간 예제 데이터 생성
+         */
+        Shop findShop = shopRepository.findAll().get(0);
+        ReservationTime reservationTime1 = ReservationFixture.getReservationTimeNotPreOccupied();
+        reservationTime1.insertShop(findShop);
+        ReservationTime savedReservationTime1 = reservationTimeRepository.save(reservationTime1);
 
         ModifyReservationRequest request = ReservationFixture.getModifyReservationRequest(
-            reservationTime.getId());
+            savedReservationTime1.getId());
 
         ReservationTime modifyReservationTime = reservationTimeRepository.findByIdAndShopId(
             request.reservationTimeId(), reservation.getShop().getId()).orElseThrow(); // 수정하려는 예약시간
@@ -149,6 +156,7 @@ class ReservationControllerTest extends BaseIntegrationTest {
 
         assertThat(savedReservation.getReservationTime()).isEqualTo(
             modifyReservationTime); // 수정하려는 예약시간으로 예약이 변경되었는 지 검증
+        assertThat(savedReservation.getReservationTime().isOccupied()).isFalse();
     }
 
     @Test

--- a/src/test/java/com/prgrms/catchtable/reservation/controller/MemberReservationControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/controller/MemberReservationControllerTest.java
@@ -1,7 +1,7 @@
 package com.prgrms.catchtable.reservation.controller;
 
 import static com.prgrms.catchtable.common.exception.ErrorCode.ALREADY_OCCUPIED_RESERVATION_TIME;
-import static com.prgrms.catchtable.reservation.domain.ReservationStatus.*;
+import static com.prgrms.catchtable.reservation.domain.ReservationStatus.CANCELLED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -13,7 +13,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.prgrms.catchtable.common.base.BaseIntegrationTest;
 import com.prgrms.catchtable.common.data.shop.ShopData;
 import com.prgrms.catchtable.reservation.domain.Reservation;
-import com.prgrms.catchtable.reservation.domain.ReservationStatus;
 import com.prgrms.catchtable.reservation.domain.ReservationTime;
 import com.prgrms.catchtable.reservation.dto.request.CreateReservationRequest;
 import com.prgrms.catchtable.reservation.dto.request.ModifyReservationRequest;
@@ -167,7 +166,7 @@ class MemberReservationControllerTest extends BaseIntegrationTest {
         Reservation savedReservation = reservationRepository.save(reservation);
 
         mockMvc.perform(delete("/reservations/{reservationId}", savedReservation.getId())
-            .contentType(APPLICATION_JSON))
+                .contentType(APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.status").value(CANCELLED.toString()));
     }

--- a/src/test/java/com/prgrms/catchtable/reservation/controller/OwnerReservationControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/controller/OwnerReservationControllerTest.java
@@ -1,0 +1,110 @@
+package com.prgrms.catchtable.reservation.controller;
+
+import static com.prgrms.catchtable.reservation.domain.ReservationStatus.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.prgrms.catchtable.common.base.BaseIntegrationTest;
+import com.prgrms.catchtable.common.data.shop.ShopData;
+import com.prgrms.catchtable.owner.domain.Owner;
+import com.prgrms.catchtable.owner.fixture.OwnerFixture;
+import com.prgrms.catchtable.owner.repository.OwnerRepository;
+import com.prgrms.catchtable.reservation.domain.Reservation;
+import com.prgrms.catchtable.reservation.domain.ReservationStatus;
+import com.prgrms.catchtable.reservation.domain.ReservationTime;
+import com.prgrms.catchtable.reservation.dto.request.ModifyReservationStatusRequest;
+import com.prgrms.catchtable.reservation.fixture.ReservationFixture;
+import com.prgrms.catchtable.reservation.repository.ReservationRepository;
+import com.prgrms.catchtable.reservation.repository.ReservationTimeRepository;
+import com.prgrms.catchtable.shop.domain.Shop;
+import com.prgrms.catchtable.shop.repository.ShopRepository;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Transactional
+class OwnerReservationControllerTest extends BaseIntegrationTest {
+    @Autowired
+    private ReservationTimeRepository reservationTimeRepository;
+    @Autowired
+    private OwnerRepository ownerRepository;
+
+    @Autowired
+    private ShopRepository shopRepository;
+    @Autowired
+    private ReservationRepository reservationRepository;
+    @BeforeEach
+    void setUp(){
+        Shop shop = shopRepository.save(ShopData.getShop());
+        ReservationTime reservationTime = ReservationFixture.getReservationTimeNotPreOccupied();
+        reservationTime.insertShop(shop);
+        ReservationTime savedReservationTime = reservationTimeRepository.save(reservationTime);
+        savedReservationTime.reverseOccupied();
+        log.info("예약 시간 차지 여부 : {}", savedReservationTime.isOccupied());
+        Reservation reservation = reservationRepository.save(
+            ReservationFixture.getReservation(savedReservationTime));
+
+        ReservationTime reservationTime2 = ReservationFixture.getAnotherReservationTimeNotPreOccupied();
+        reservationTime2.insertShop(shop);
+        ReservationTime savedReservationTime2 = reservationTimeRepository.save(reservationTime2);
+        savedReservationTime2.reverseOccupied();
+        log.info("예약 시간 차지 여부 : {}", savedReservationTime.isOccupied());
+        Reservation reservation2 = reservationRepository.save(
+            ReservationFixture.getReservation(savedReservationTime2));
+
+        Owner owner = OwnerFixture.getOwner();
+        owner.insertShop(shop);
+        ownerRepository.save(owner);
+    }
+
+    @Test
+    @DisplayName("점주는 예약상태를 변경시킬 수 있다")
+    void modifyReservationStatus() throws Exception {
+        //given
+        Reservation reservation = reservationRepository.findAll().get(0);
+
+        ModifyReservationStatusRequest request = ModifyReservationStatusRequest.builder()
+            .status(CANCELLED)
+            .build();
+
+        //then
+        assertThat(reservation.getReservationTime().isOccupied()).isTrue(); // 취소처리 전엔 예약시간 차있음
+        mockMvc.perform(post("/owners/shop/{reservationId}", reservation.getId())
+            .contentType(APPLICATION_JSON)
+            .content(asJsonString(request)))
+            .andExpect(status().isOk());
+
+        assertThat(reservation.getStatus()).isEqualTo(request.status());
+        assertThat(reservation.getReservationTime().isOccupied()).isFalse(); // 취소처리 후엔 예약시간 비어있음
+    }
+
+    @Test
+    @DisplayName("점주는 예약된 정보들을 전체 조회할 수 있다.")
+    void getAllReservation() throws Exception {
+        List<Reservation> reservations = reservationRepository.findAllWithReservationTimeAndShop();
+        Reservation reservation1 = reservations.get(0);
+        Reservation reservation2 = reservations.get(1);
+
+        Owner owner = ownerRepository.findAll().get(0);
+
+        mockMvc.perform(get("/owners/shop")
+                .contentType(APPLICATION_JSON)
+                .content(asJsonString(owner.getId())))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].date").value(reservation1.getReservationTime().getTime().toString()))
+            .andExpect(jsonPath("$[0].peopleCount").value(reservation1.getPeopleCount()))
+            .andExpect(jsonPath("$[1].date").value(reservation2.getReservationTime().getTime().toString()))
+            .andExpect(jsonPath("$[1].peopleCount").value(reservation2.getPeopleCount()));
+    }
+}

--- a/src/test/java/com/prgrms/catchtable/reservation/controller/OwnerReservationControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/controller/OwnerReservationControllerTest.java
@@ -1,8 +1,8 @@
 package com.prgrms.catchtable.reservation.controller;
 
-import static com.prgrms.catchtable.reservation.domain.ReservationStatus.*;
-import static org.assertj.core.api.Assertions.*;
-import static org.springframework.http.MediaType.*;
+import static com.prgrms.catchtable.reservation.domain.ReservationStatus.CANCELLED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -14,7 +14,6 @@ import com.prgrms.catchtable.owner.domain.Owner;
 import com.prgrms.catchtable.owner.fixture.OwnerFixture;
 import com.prgrms.catchtable.owner.repository.OwnerRepository;
 import com.prgrms.catchtable.reservation.domain.Reservation;
-import com.prgrms.catchtable.reservation.domain.ReservationStatus;
 import com.prgrms.catchtable.reservation.domain.ReservationTime;
 import com.prgrms.catchtable.reservation.dto.request.ModifyReservationStatusRequest;
 import com.prgrms.catchtable.reservation.fixture.ReservationFixture;
@@ -24,17 +23,16 @@ import com.prgrms.catchtable.shop.domain.Shop;
 import com.prgrms.catchtable.shop.repository.ShopRepository;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.MediaType;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Transactional
 class OwnerReservationControllerTest extends BaseIntegrationTest {
+
     @Autowired
     private ReservationTimeRepository reservationTimeRepository;
     @Autowired
@@ -44,8 +42,9 @@ class OwnerReservationControllerTest extends BaseIntegrationTest {
     private ShopRepository shopRepository;
     @Autowired
     private ReservationRepository reservationRepository;
+
     @BeforeEach
-    void setUp(){
+    void setUp() {
         Shop shop = shopRepository.save(ShopData.getShop());
         ReservationTime reservationTime = ReservationFixture.getReservationTimeNotPreOccupied();
         reservationTime.insertShop(shop);
@@ -81,8 +80,8 @@ class OwnerReservationControllerTest extends BaseIntegrationTest {
         //then
         assertThat(reservation.getReservationTime().isOccupied()).isTrue(); // 취소처리 전엔 예약시간 차있음
         mockMvc.perform(post("/owners/shop/{reservationId}", reservation.getId())
-            .contentType(APPLICATION_JSON)
-            .content(asJsonString(request)))
+                .contentType(APPLICATION_JSON)
+                .content(asJsonString(request)))
             .andExpect(status().isOk());
 
         assertThat(reservation.getStatus()).isEqualTo(request.status());
@@ -102,9 +101,11 @@ class OwnerReservationControllerTest extends BaseIntegrationTest {
                 .contentType(APPLICATION_JSON)
                 .content(asJsonString(owner.getId())))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$[0].date").value(reservation1.getReservationTime().getTime().toString()))
+            .andExpect(
+                jsonPath("$[0].date").value(reservation1.getReservationTime().getTime().toString()))
             .andExpect(jsonPath("$[0].peopleCount").value(reservation1.getPeopleCount()))
-            .andExpect(jsonPath("$[1].date").value(reservation2.getReservationTime().getTime().toString()))
+            .andExpect(
+                jsonPath("$[1].date").value(reservation2.getReservationTime().getTime().toString()))
             .andExpect(jsonPath("$[1].peopleCount").value(reservation2.getPeopleCount()));
     }
 }

--- a/src/test/java/com/prgrms/catchtable/reservation/fixture/ReservationFixture.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/fixture/ReservationFixture.java
@@ -17,7 +17,7 @@ public class ReservationFixture {
 
 
     public static Reservation getReservation(ReservationTime reservationTime) {
-        if(!reservationTime.isOccupied()){
+        if (!reservationTime.isOccupied()) {
             reservationTime.reverseOccupied();
         }
         return Reservation.builder()
@@ -89,7 +89,7 @@ public class ReservationFixture {
     }
 
     public static ModifyReservationStatusRequest getModifyReservationStatusRequest(
-        ReservationStatus status){
+        ReservationStatus status) {
         return ModifyReservationStatusRequest.builder()
             .status(status)
             .build();

--- a/src/test/java/com/prgrms/catchtable/reservation/fixture/ReservationFixture.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/fixture/ReservationFixture.java
@@ -4,9 +4,11 @@ import static com.prgrms.catchtable.reservation.domain.ReservationStatus.COMPLET
 
 import com.prgrms.catchtable.common.data.shop.ShopData;
 import com.prgrms.catchtable.reservation.domain.Reservation;
+import com.prgrms.catchtable.reservation.domain.ReservationStatus;
 import com.prgrms.catchtable.reservation.domain.ReservationTime;
 import com.prgrms.catchtable.reservation.dto.request.CreateReservationRequest;
 import com.prgrms.catchtable.reservation.dto.request.ModifyReservationRequest;
+import com.prgrms.catchtable.reservation.dto.request.ModifyReservationStatusRequest;
 import com.prgrms.catchtable.shop.domain.Shop;
 import java.time.LocalDateTime;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -15,6 +17,9 @@ public class ReservationFixture {
 
 
     public static Reservation getReservation(ReservationTime reservationTime) {
+        if(!reservationTime.isOccupied()){
+            reservationTime.reverseOccupied();
+        }
         return Reservation.builder()
             .status(COMPLETED)
             .peopleCount(4)
@@ -81,6 +86,13 @@ public class ReservationFixture {
         reservationTime.insertShop(shop);
         reservationTime.reverseOccupied();
         return reservationTime;
+    }
+
+    public static ModifyReservationStatusRequest getModifyReservationStatusRequest(
+        ReservationStatus status){
+        return ModifyReservationStatusRequest.builder()
+            .status(status)
+            .build();
     }
 
 }

--- a/src/test/java/com/prgrms/catchtable/reservation/repository/ReservationRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/repository/ReservationRepositoryTest.java
@@ -49,6 +49,7 @@ class ReservationRepositoryTest {
             () -> assertThat(findReservation.getShop()).isEqualTo(savedShop)
         );
     }
+
     @Test
     @DisplayName("예약 Id를 통해 예약(예약시간, 매장까지)을 조회할 수 있다.")
     void findByIdWithReservationTimeAndShop() {
@@ -67,13 +68,14 @@ class ReservationRepositoryTest {
         assertAll(
             () -> assertThat(findReservation.getReservationTime()).isEqualTo(savedReservationTime),
             () -> assertThat(findReservation.getShop()).isEqualTo(savedShop),
-            () -> assertThat(findReservation.getPeopleCount()).isEqualTo(savedReservation.getPeopleCount())
+            () -> assertThat(findReservation.getPeopleCount()).isEqualTo(
+                savedReservation.getPeopleCount())
         );
     }
 
     @Test
     @DisplayName("가게 아이디와 일치하는 예약을 전체 조회할 수 있다")
-    void getAllReservationByShopId(){
+    void getAllReservationByShopId() {
         /**
          * 첫번째 예제 예약 데이터 저장
          */
@@ -92,7 +94,8 @@ class ReservationRepositoryTest {
         Shop otherShop = ShopFixture.shop();
         Shop otherSavedShop = shopRepository.save(otherShop);
         otherReservationTime.insertShop(otherSavedShop);
-        ReservationTime otherSavedReservationTime = reservationTimeRepository.save(otherReservationTime);
+        ReservationTime otherSavedReservationTime = reservationTimeRepository.save(
+            otherReservationTime);
         Reservation otherReservation = ReservationFixture.getReservation(otherSavedReservationTime);
 
         reservationRepository.save(otherReservation);

--- a/src/test/java/com/prgrms/catchtable/reservation/service/MemberReservationServiceIntegrationTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/service/MemberReservationServiceIntegrationTest.java
@@ -22,10 +22,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-public class ReservationServiceIntegrationTest {
+public class MemberReservationServiceIntegrationTest {
 
     @Autowired
-    private ReservationService reservationService;
+    private MemberReservationService memberReservationService;
     @Autowired
     private ReservationTimeRepository reservationTimeRepository;
 
@@ -59,7 +59,7 @@ public class ReservationServiceIntegrationTest {
         for (int i = 0; i < threadCount; i++) {
             executorService.submit(() -> {
                 try {
-                    reservationService.preOccupyReservation(request);
+                    memberReservationService.preOccupyReservation(request);
                 } catch (BadRequestCustomException e) {
                     errorCount.incrementAndGet();
                 } finally {

--- a/src/test/java/com/prgrms/catchtable/reservation/service/MemberReservationServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/service/MemberReservationServiceTest.java
@@ -250,7 +250,8 @@ class MemberReservationServiceTest {
         Reservation reservation = ReservationFixture.getReservation(reservationTime);
         ReflectionTestUtils.setField(reservation, "id", 1L);
 
-        when(reservationRepository.findByIdWithReservationTimeAndShop(1L)).thenReturn(Optional.of(reservation));
+        when(reservationRepository.findByIdWithReservationTimeAndShop(1L)).thenReturn(
+            Optional.of(reservation));
 
         //when
         CancelReservationResponse response = memberReservationService.cancelReservation(
@@ -267,10 +268,12 @@ class MemberReservationServiceTest {
 
     @Test
     @DisplayName("존재하지 않는 예약에 대한 삭제 요청 시 예외가 발생한다")
-    void cancelReservationNotExist(){
-        when(reservationRepository.findByIdWithReservationTimeAndShop(1L)).thenReturn(Optional.empty());
+    void cancelReservationNotExist() {
+        when(reservationRepository.findByIdWithReservationTimeAndShop(1L)).thenReturn(
+            Optional.empty());
 
-        assertThrows(NotFoundCustomException.class, () -> memberReservationService.cancelReservation(1L));
+        assertThrows(NotFoundCustomException.class,
+            () -> memberReservationService.cancelReservation(1L));
     }
 
 }

--- a/src/test/java/com/prgrms/catchtable/reservation/service/MemberReservationServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/service/MemberReservationServiceTest.java
@@ -37,7 +37,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
-class ReservationServiceTest {
+class MemberReservationServiceTest {
 
     @Mock
     private ReservationRepository reservationRepository;
@@ -48,7 +48,7 @@ class ReservationServiceTest {
     @Mock
     private ReservationTimeRepository reservationTimeRepository;
     @InjectMocks
-    private ReservationService reservationService;
+    private MemberReservationService memberReservationService;
 
     @Test
     @DisplayName("예약시간의 선점 여부를 검증하고 선점권이 빈 것을 확인한다.")
@@ -64,7 +64,7 @@ class ReservationServiceTest {
         when(reservationLockRepository.unlock(1L)).thenReturn(TRUE);
         doNothing().when(reservationAsync).setPreOcuppied(reservationTime);
         //when
-        CreateReservationResponse response = reservationService.preOccupyReservation(
+        CreateReservationResponse response = memberReservationService.preOccupyReservation(
             request);
 
         //then
@@ -91,7 +91,7 @@ class ReservationServiceTest {
 
         //when
         assertThrows(BadRequestCustomException.class,
-            () -> reservationService.preOccupyReservation(request));
+            () -> memberReservationService.preOccupyReservation(request));
 
 
     }
@@ -111,7 +111,7 @@ class ReservationServiceTest {
             Optional.of(reservationTime));
         when(reservationRepository.save(any(Reservation.class))).thenReturn(reservation);
 
-        CreateReservationResponse response = reservationService.registerReservation(request);
+        CreateReservationResponse response = memberReservationService.registerReservation(request);
 
         assertAll(
             () -> assertThat(response.date()).isEqualTo(reservationTime.getTime()),
@@ -131,7 +131,7 @@ class ReservationServiceTest {
             Optional.of(reservationTime));
 
         assertThrows(BadRequestCustomException.class,
-            () -> reservationService.registerReservation(request));
+            () -> memberReservationService.registerReservation(request));
     }
 
     @Test
@@ -142,7 +142,7 @@ class ReservationServiceTest {
 
         when(reservationRepository.findAllWithReservationTimeAndShop()).thenReturn(
             List.of(reservation));
-        List<GetAllReservationResponse> all = reservationService.getAllReservation();
+        List<GetAllReservationResponse> all = memberReservationService.getAllReservation();
         GetAllReservationResponse findReservation = all.get(0);
 
         assertAll(
@@ -159,7 +159,7 @@ class ReservationServiceTest {
     void getAllReservationWithNoResult() {
         when(reservationRepository.findAllWithReservationTimeAndShop()).thenReturn(List.of());
 
-        List<GetAllReservationResponse> all = reservationService.getAllReservation();
+        List<GetAllReservationResponse> all = memberReservationService.getAllReservation();
         assertThat(all).isEmpty();
     }
 
@@ -187,7 +187,7 @@ class ReservationServiceTest {
             Optional.of(modifyTime));
 
         //when
-        ModifyReservationResponse response = reservationService.modifyReservation(
+        ModifyReservationResponse response = memberReservationService.modifyReservation(
             1L, request); // 예약 id가 1인 예약 정보 변경
 
         //then
@@ -206,7 +206,7 @@ class ReservationServiceTest {
             Optional.empty());
 
         assertThrows(BadRequestCustomException.class,
-            () -> reservationService.modifyReservation(1L, request));
+            () -> memberReservationService.modifyReservation(1L, request));
     }
 
     @Test
@@ -222,7 +222,7 @@ class ReservationServiceTest {
             any(Long.class))).thenReturn(Optional.of(reservationTime));
 
         assertThrows(BadRequestCustomException.class,
-            () -> reservationService.modifyReservation(1L, request));
+            () -> memberReservationService.modifyReservation(1L, request));
     }
 
     @Test
@@ -238,7 +238,7 @@ class ReservationServiceTest {
             any(Long.class))).thenReturn(Optional.of(reservationTime));
 
         assertThrows(BadRequestCustomException.class,
-            () -> reservationService.modifyReservation(1L, request));
+            () -> memberReservationService.modifyReservation(1L, request));
     }
 
     @Test
@@ -253,7 +253,7 @@ class ReservationServiceTest {
         when(reservationRepository.findByIdWithReservationTimeAndShop(1L)).thenReturn(Optional.of(reservation));
 
         //when
-        CancelReservationResponse response = reservationService.cancelReservation(
+        CancelReservationResponse response = memberReservationService.cancelReservation(
             reservation.getId());
 
         //then
@@ -270,7 +270,7 @@ class ReservationServiceTest {
     void cancelReservationNotExist(){
         when(reservationRepository.findByIdWithReservationTimeAndShop(1L)).thenReturn(Optional.empty());
 
-        assertThrows(NotFoundCustomException.class, () -> reservationService.cancelReservation(1L));
+        assertThrows(NotFoundCustomException.class, () -> memberReservationService.cancelReservation(1L));
     }
 
 }

--- a/src/test/java/com/prgrms/catchtable/reservation/service/OwnerReservationServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/service/OwnerReservationServiceTest.java
@@ -1,8 +1,10 @@
 package com.prgrms.catchtable.reservation.service;
 
-import static com.prgrms.catchtable.reservation.domain.ReservationStatus.*;
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static com.prgrms.catchtable.reservation.domain.ReservationStatus.CANCELLED;
+import static com.prgrms.catchtable.reservation.domain.ReservationStatus.NO_SHOW;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -11,7 +13,6 @@ import com.prgrms.catchtable.owner.domain.Owner;
 import com.prgrms.catchtable.owner.fixture.OwnerFixture;
 import com.prgrms.catchtable.owner.repository.OwnerRepository;
 import com.prgrms.catchtable.reservation.domain.Reservation;
-import com.prgrms.catchtable.reservation.domain.ReservationStatus;
 import com.prgrms.catchtable.reservation.domain.ReservationTime;
 import com.prgrms.catchtable.reservation.dto.request.ModifyReservationStatusRequest;
 import com.prgrms.catchtable.reservation.dto.response.OwnerGetAllReservationResponse;
@@ -21,7 +22,6 @@ import com.prgrms.catchtable.shop.domain.Shop;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,20 +29,20 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.testcontainers.shaded.org.checkerframework.checker.units.qual.A;
 
 @ExtendWith(MockitoExtension.class)
 class OwnerReservationServiceTest {
+
     @Mock
     private ReservationRepository reservationRepository;
     @Mock
     private OwnerRepository ownerRepository;
     @InjectMocks
     private OwnerReservationService ownerReservationService;
-    
+
     @Test
     @DisplayName("점주는 특정 예약을 노쇼처리 할 수 있다.")
-    void noshowReservation(){
+    void noshowReservation() {
         ReservationTime reservationTime = ReservationFixture.getReservationTimeOccupied();
         Reservation reservation = ReservationFixture.getReservation(reservationTime);
         ModifyReservationStatusRequest request = ReservationFixture.getModifyReservationStatusRequest(
@@ -55,13 +55,14 @@ class OwnerReservationServiceTest {
 
         assertAll(
             () -> assertThat(reservation.getStatus()).isEqualTo(NO_SHOW), // 예약 상태가 노쇼로 바뀌어야함
-            () -> assertThat(reservation.getReservationTime().isOccupied()).isFalse() // 예약한 예약시간의 차지여부가 false가 되어야함
+            () -> assertThat(reservation.getReservationTime().isOccupied()).isFalse()
+            // 예약한 예약시간의 차지여부가 false가 되어야함
         );
     }
 
     @Test
     @DisplayName("점주는 특정 예약을 취소처리 할 수 있다.")
-    void cancelReservation(){
+    void cancelReservation() {
         ReservationTime reservationTime = ReservationFixture.getReservationTimeOccupied();
         Reservation reservation = ReservationFixture.getReservation(reservationTime);
         ModifyReservationStatusRequest request = ReservationFixture.getModifyReservationStatusRequest(
@@ -80,7 +81,7 @@ class OwnerReservationServiceTest {
 
     @Test
     @DisplayName("존재하지 않는 예약을 노쇼,취소 처리하려 하면 예외가 발생한다")
-    void modifyReservationNotExist(){
+    void modifyReservationNotExist() {
         ModifyReservationStatusRequest request = ReservationFixture.getModifyReservationStatusRequest(
             CANCELLED);
 
@@ -93,7 +94,7 @@ class OwnerReservationServiceTest {
 
     @Test
     @DisplayName("점주는 가게의 예약을 전체 조회할 수 있다")
-    void getAllReservation(){
+    void getAllReservation() {
         List<Reservation> reservations = new ArrayList<>();
         ReservationTime reservationTime1 = ReservationFixture.getReservationTimeNotPreOccupied();
         ReservationTime reservationTime2 = ReservationFixture.getAnotherReservationTimeNotPreOccupied();
@@ -109,23 +110,27 @@ class OwnerReservationServiceTest {
         reservations.add(reservation1);
         reservations.add(reservation2);
         Owner owner = OwnerFixture.getOwner();
-        when(reservationRepository.findAllWithReservationTimeAndShopByShopId(any(Long.class))).thenReturn(reservations);
+        when(reservationRepository.findAllWithReservationTimeAndShopByShopId(
+            any(Long.class))).thenReturn(reservations);
         when(ownerRepository.findById(any(Long.class))).thenReturn(Optional.of(owner));
         List<OwnerGetAllReservationResponse> allReservation = ownerReservationService.getAllReservation(
             1L);
 
         assertAll(
-            () -> assertThat(allReservation.get(0).date()).isEqualTo(reservation1.getReservationTime().getTime()),
-            () -> assertThat(allReservation.get(1).date()).isEqualTo(reservation2.getReservationTime().getTime())
+            () -> assertThat(allReservation.get(0).date()).isEqualTo(
+                reservation1.getReservationTime().getTime()),
+            () -> assertThat(allReservation.get(1).date()).isEqualTo(
+                reservation2.getReservationTime().getTime())
         );
     }
 
     @Test
     @DisplayName("매장에 예약이 없을 시 빈 리스트가 조회된다.")
-    void getAllReservationEmpty(){
+    void getAllReservationEmpty() {
         Owner owner = OwnerFixture.getOwner();
 
-        when(reservationRepository.findAllWithReservationTimeAndShopByShopId(any(Long.class))).thenReturn(List.of());
+        when(reservationRepository.findAllWithReservationTimeAndShopByShopId(
+            any(Long.class))).thenReturn(List.of());
         when(ownerRepository.findById(any(Long.class))).thenReturn(Optional.of(owner));
 
         List<OwnerGetAllReservationResponse> allReservation = ownerReservationService.getAllReservation(

--- a/src/test/java/com/prgrms/catchtable/reservation/service/OwnerReservationServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/service/OwnerReservationServiceTest.java
@@ -1,0 +1,137 @@
+package com.prgrms.catchtable.reservation.service;
+
+import static com.prgrms.catchtable.reservation.domain.ReservationStatus.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
+import com.prgrms.catchtable.owner.domain.Owner;
+import com.prgrms.catchtable.owner.fixture.OwnerFixture;
+import com.prgrms.catchtable.owner.repository.OwnerRepository;
+import com.prgrms.catchtable.reservation.domain.Reservation;
+import com.prgrms.catchtable.reservation.domain.ReservationStatus;
+import com.prgrms.catchtable.reservation.domain.ReservationTime;
+import com.prgrms.catchtable.reservation.dto.request.ModifyReservationStatusRequest;
+import com.prgrms.catchtable.reservation.dto.response.OwnerGetAllReservationResponse;
+import com.prgrms.catchtable.reservation.fixture.ReservationFixture;
+import com.prgrms.catchtable.reservation.repository.ReservationRepository;
+import com.prgrms.catchtable.shop.domain.Shop;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.testcontainers.shaded.org.checkerframework.checker.units.qual.A;
+
+@ExtendWith(MockitoExtension.class)
+class OwnerReservationServiceTest {
+    @Mock
+    private ReservationRepository reservationRepository;
+    @Mock
+    private OwnerRepository ownerRepository;
+    @InjectMocks
+    private OwnerReservationService ownerReservationService;
+    
+    @Test
+    @DisplayName("점주는 특정 예약을 노쇼처리 할 수 있다.")
+    void noshowReservation(){
+        ReservationTime reservationTime = ReservationFixture.getReservationTimeOccupied();
+        Reservation reservation = ReservationFixture.getReservation(reservationTime);
+        ModifyReservationStatusRequest request = ReservationFixture.getModifyReservationStatusRequest(
+            NO_SHOW);
+
+        when(reservationRepository.findByIdWithReservationTimeAndShop(any(Long.class))).thenReturn(
+            Optional.of(reservation));
+
+        ownerReservationService.modifyReservationStatus(1L, request);
+
+        assertAll(
+            () -> assertThat(reservation.getStatus()).isEqualTo(NO_SHOW), // 예약 상태가 노쇼로 바뀌어야함
+            () -> assertThat(reservation.getReservationTime().isOccupied()).isFalse() // 예약한 예약시간의 차지여부가 false가 되어야함
+        );
+    }
+
+    @Test
+    @DisplayName("점주는 특정 예약을 취소처리 할 수 있다.")
+    void cancelReservation(){
+        ReservationTime reservationTime = ReservationFixture.getReservationTimeOccupied();
+        Reservation reservation = ReservationFixture.getReservation(reservationTime);
+        ModifyReservationStatusRequest request = ReservationFixture.getModifyReservationStatusRequest(
+            CANCELLED);
+
+        when(reservationRepository.findByIdWithReservationTimeAndShop(any(Long.class))).thenReturn(
+            Optional.of(reservation));
+
+        ownerReservationService.modifyReservationStatus(1L, request);
+
+        assertAll(
+            () -> assertThat(reservation.getStatus()).isEqualTo(CANCELLED),
+            () -> assertThat(reservation.getReservationTime().isOccupied()).isFalse()
+        );
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 예약을 노쇼,취소 처리하려 하면 예외가 발생한다")
+    void modifyReservationNotExist(){
+        ModifyReservationStatusRequest request = ReservationFixture.getModifyReservationStatusRequest(
+            CANCELLED);
+
+        when(reservationRepository.findByIdWithReservationTimeAndShop(any(Long.class))).thenReturn(
+            Optional.empty());
+
+        assertThrows(NotFoundCustomException.class,
+            () -> ownerReservationService.modifyReservationStatus(1L, request));
+    }
+
+    @Test
+    @DisplayName("점주는 가게의 예약을 전체 조회할 수 있다")
+    void getAllReservation(){
+        List<Reservation> reservations = new ArrayList<>();
+        ReservationTime reservationTime1 = ReservationFixture.getReservationTimeNotPreOccupied();
+        ReservationTime reservationTime2 = ReservationFixture.getAnotherReservationTimeNotPreOccupied();
+
+        Shop shop1 = reservationTime1.getShop();
+        Shop shop2 = reservationTime2.getShop();
+        ReflectionTestUtils.setField(shop1, "id", 1L);
+        ReflectionTestUtils.setField(shop2, "id", 2L);
+
+        Reservation reservation1 = ReservationFixture.getReservation(reservationTime1);
+        Reservation reservation2 = ReservationFixture.getReservation(reservationTime2);
+
+        reservations.add(reservation1);
+        reservations.add(reservation2);
+        Owner owner = OwnerFixture.getOwner();
+        when(reservationRepository.findAllWithReservationTimeAndShopByShopId(any(Long.class))).thenReturn(reservations);
+        when(ownerRepository.findById(any(Long.class))).thenReturn(Optional.of(owner));
+        List<OwnerGetAllReservationResponse> allReservation = ownerReservationService.getAllReservation(
+            1L);
+
+        assertAll(
+            () -> assertThat(allReservation.get(0).date()).isEqualTo(reservation1.getReservationTime().getTime()),
+            () -> assertThat(allReservation.get(1).date()).isEqualTo(reservation2.getReservationTime().getTime())
+        );
+    }
+
+    @Test
+    @DisplayName("매장에 예약이 없을 시 빈 리스트가 조회된다.")
+    void getAllReservationEmpty(){
+        Owner owner = OwnerFixture.getOwner();
+
+        when(reservationRepository.findAllWithReservationTimeAndShopByShopId(any(Long.class))).thenReturn(List.of());
+        when(ownerRepository.findById(any(Long.class))).thenReturn(Optional.of(owner));
+
+        List<OwnerGetAllReservationResponse> allReservation = ownerReservationService.getAllReservation(
+            1L);
+
+        assertThat(allReservation).isEmpty();
+    }
+
+}

--- a/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepositoryTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class BasicWaitingLineRepositoryTest{
+class BasicWaitingLineRepositoryTest {
 
     private final BasicWaitingLineRepository repository = new BasicWaitingLineRepository();
 

--- a/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepositoryTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
-import com.prgrms.catchtable.waiting.repository.waitingline.RedisWaitingLineRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
close #58 
### ⛏ 작업 상세 내용

- OwneReservationService, OwnerReservationController
    - 예약 상태를 노쇼, 취소 처리하는 로직과 점주 가게의 예약을 전체 조회하는 로직 구성
    - 전체 조회 시 일단은 인자로 owner의 id 값을 받는 것으로 해놓았는데 추후에 엔티티로 바꿀 예정입니다.
- Owner.java
    - Owner와 Shop의 연관관계 맺어주는 메소드 추가(insertShop())
- ReservationRepository.java
    - 점주의 가게에 대한 예약들만 가져오는 쿼리 추가
- Service, Controller test 완료
- 참고로 선점여부와 예약됨 여부를 뒤집는 메소드가 있는데 이는 다음 pr에서 setTrue, setFalse 이런식으로 리팩토링 예정입니다. (코드 가독성 측면)


### 📝 작업 요약

- Owner의 예약 상태 수정, 전체조회 API 구현완료

### **☑️** 중점적으로 리뷰 할 부분

- 비즈니스 로직
- 테스트 코드가 조금 복잡할 수 있는데 주석 달아놓았으니 천천히 보시면서 잘못된 부분이나 추가되었으면 하는 테스트 생각나시면 리뷰 남겨주세요~!
- (전의 코드들이 포맷팅이 안된 상태라서 이전 Pr들 머지된 후 포맷팅 하겠습니다)
