### PR TITLE
feat : 대기 순서 지연 API 구현

### DIFF
--- a/src/main/java/com/prgrms/catchtable/common/exception/ErrorCode.java
+++ b/src/main/java/com/prgrms/catchtable/common/exception/ErrorCode.java
@@ -19,7 +19,10 @@ public enum ErrorCode {
 
     CAN_NOT_COMPLETE_WAITING("입장 처리가 불가한 대기 상태입니다."),
     EXISTING_MEMBER_WAITING("이미 회원이 웨이팅 중인 가게가 존재합니다."),
-    ALREADY_END_LINE("이미 맨뒤라 지연할 수 없습니다."),
+    ALREADY_END_LINE("이미 맨뒤라 웨이팅을 미룰 수 없습니다."),
+    NOT_EXIST_WAITING("웨이팅이 존재하지 않습니다."),
+
+    POSTPONE_REMAINING_CNT_0("이미 두 차례 대기를 미뤘습니다."),
 
     CAN_NOT_ENTRY("웨이팅을 입장 처리할 수 없습니다"),
     WAITING_DOES_NOT_EXIST("웨이팅이 존재하지 않습니다"),

--- a/src/main/java/com/prgrms/catchtable/waiting/controller/WaitingController.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/controller/WaitingController.java
@@ -6,6 +6,7 @@ import com.prgrms.catchtable.waiting.service.WaitingService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,6 +25,13 @@ public class WaitingController {
         @PathVariable("memberId") Long memberId,
         @Valid @RequestBody CreateWaitingRequest request) {
         WaitingResponse response = waitingService.createWaiting(shopId, memberId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/{memberId}")
+    public ResponseEntity<WaitingResponse> postponeWaiting(
+        @PathVariable("memberId") Long memberId) {
+        WaitingResponse response = waitingService.postponeWaiting(memberId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/prgrms/catchtable/waiting/domain/Waiting.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/domain/Waiting.java
@@ -1,6 +1,7 @@
 package com.prgrms.catchtable.waiting.domain;
 
 import static com.prgrms.catchtable.common.exception.ErrorCode.CAN_NOT_COMPLETE_WAITING;
+import static com.prgrms.catchtable.common.exception.ErrorCode.POSTPONE_REMAINING_CNT_0;
 import static com.prgrms.catchtable.waiting.domain.WaitingStatus.CANCELED;
 import static com.prgrms.catchtable.waiting.domain.WaitingStatus.COMPLETED;
 import static com.prgrms.catchtable.waiting.domain.WaitingStatus.NO_SHOW;
@@ -67,6 +68,16 @@ public class Waiting extends BaseEntity {
         this.shop = shop;
         status = PROGRESS;
         postponeRemainingCount = 2;
+    }
+
+    public void validatePostponeRemainingCount() {
+        if (postponeRemainingCount==0){
+            throw new BadRequestCustomException(POSTPONE_REMAINING_CNT_0);
+        }
+    }
+
+    public void decreasePostponeRemainingCount(){
+        postponeRemainingCount--;
     }
 
     public void completeWaiting() {

--- a/src/main/java/com/prgrms/catchtable/waiting/domain/Waiting.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/domain/Waiting.java
@@ -71,12 +71,12 @@ public class Waiting extends BaseEntity {
     }
 
     public void validatePostponeRemainingCount() {
-        if (postponeRemainingCount==0){
+        if (postponeRemainingCount == 0) {
             throw new BadRequestCustomException(POSTPONE_REMAINING_CNT_0);
         }
     }
 
-    public void decreasePostponeRemainingCount(){
+    public void decreasePostponeRemainingCount() {
         postponeRemainingCount--;
     }
 

--- a/src/main/java/com/prgrms/catchtable/waiting/domain/Waiting.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/domain/Waiting.java
@@ -49,8 +49,8 @@ public class Waiting extends BaseEntity {
     @Enumerated(STRING)
     private WaitingStatus status;
 
-    @Column(name = "postpone_remaining_count")
-    private int postponeRemainingCount;
+    @Column(name = "remaining_postpone_count")
+    private int remainingPostponeCount;
 
     @OneToOne(fetch = LAZY)
     @JoinColumn(name = "member_id", foreignKey = @ForeignKey(NO_CONSTRAINT))
@@ -67,17 +67,17 @@ public class Waiting extends BaseEntity {
         this.member = member;
         this.shop = shop;
         status = PROGRESS;
-        postponeRemainingCount = 2;
+        remainingPostponeCount = 2;
     }
 
     public void validatePostponeRemainingCount() {
-        if (postponeRemainingCount == 0) {
+        if (remainingPostponeCount == 0) {
             throw new BadRequestCustomException(POSTPONE_REMAINING_CNT_0);
         }
     }
 
     public void decreasePostponeRemainingCount() {
-        postponeRemainingCount--;
+        remainingPostponeCount--;
     }
 
     public void completeWaiting() {

--- a/src/main/java/com/prgrms/catchtable/waiting/dto/WaitingMapper.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/dto/WaitingMapper.java
@@ -29,7 +29,7 @@ public class WaitingMapper {
             .peopleCount(waiting.getPeopleCount())
             .waitingNumber(waiting.getWaitingNumber())
             .rank(rank)
-            .remainingPostponeCount(waiting.getPostponeRemainingCount())
+            .remainingPostponeCount(waiting.getRemainingPostponeCount())
             .build();
     }
 }

--- a/src/main/java/com/prgrms/catchtable/waiting/dto/WaitingMapper.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/dto/WaitingMapper.java
@@ -21,7 +21,7 @@ public class WaitingMapper {
     }
 
     // entity -> dto
-    public static WaitingResponse toCreateWaitingResponse(Waiting waiting, Long rank) {
+    public static WaitingResponse toWaitingResponse(Waiting waiting, Long rank) {
         return WaitingResponse.builder()
             .createdWaitingId(waiting.getId())
             .shopId(waiting.getShop().getId())

--- a/src/main/java/com/prgrms/catchtable/waiting/dto/WaitingMapper.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/dto/WaitingMapper.java
@@ -23,12 +23,13 @@ public class WaitingMapper {
     // entity -> dto
     public static WaitingResponse toWaitingResponse(Waiting waiting, Long rank) {
         return WaitingResponse.builder()
-            .createdWaitingId(waiting.getId())
+            .waitingId(waiting.getId())
             .shopId(waiting.getShop().getId())
             .shopName(waiting.getShop().getName())
             .peopleCount(waiting.getPeopleCount())
             .waitingNumber(waiting.getWaitingNumber())
             .rank(rank)
+            .remainingPostponeCount(waiting.getPostponeRemainingCount())
             .build();
     }
 }

--- a/src/main/java/com/prgrms/catchtable/waiting/dto/WaitingResponse.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/dto/WaitingResponse.java
@@ -4,12 +4,13 @@ import lombok.Builder;
 
 @Builder
 public record WaitingResponse(
-    Long createdWaitingId,
+    Long waitingId,
     Long shopId,
     String shopName,
     int peopleCount,
     int waitingNumber,
-    Long rank
+    Long rank,
+    int remainingPostponeCount
 ) {
 
 }

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/WaitingRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/WaitingRepository.java
@@ -6,12 +6,15 @@ import com.prgrms.catchtable.waiting.domain.Waiting;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface WaitingRepository extends JpaRepository<Waiting, Long> {
 
     boolean existsByMember(Member member);
 
-    Optional<Waiting> findByMember(Member member);
+    @Query("select w from Waiting w join fetch w.shop where w.member = :member")
+    Optional<Waiting> findByMemberWithShop(@Param("member")Member member);
 
     Long countByShopAndCreatedAtBetween(Shop shop, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/WaitingRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/WaitingRepository.java
@@ -4,11 +4,14 @@ import com.prgrms.catchtable.member.domain.Member;
 import com.prgrms.catchtable.shop.domain.Shop;
 import com.prgrms.catchtable.waiting.domain.Waiting;
 import java.time.LocalDateTime;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface WaitingRepository extends JpaRepository<Waiting, Long> {
 
     boolean existsByMember(Member member);
+
+    Optional<Waiting> findByMember(Member member);
 
     Long countByShopAndCreatedAtBetween(Shop shop, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/WaitingRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/WaitingRepository.java
@@ -14,7 +14,7 @@ public interface WaitingRepository extends JpaRepository<Waiting, Long> {
     boolean existsByMember(Member member);
 
     @Query("select w from Waiting w join fetch w.shop where w.member = :member")
-    Optional<Waiting> findByMemberWithShop(@Param("member")Member member);
+    Optional<Waiting> findByMemberWithShop(@Param("member") Member member);
 
     Long countByShopAndCreatedAtBetween(Shop shop, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/prgrms/catchtable/waiting/service/WaitingService.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/service/WaitingService.java
@@ -4,8 +4,8 @@ import static com.prgrms.catchtable.common.exception.ErrorCode.EXISTING_MEMBER_W
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_MEMBER;
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_SHOP;
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_WAITING;
-import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toWaitingResponse;
 import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toWaiting;
+import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toWaitingResponse;
 
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
@@ -60,7 +60,7 @@ public class WaitingService {
         return toWaitingResponse(savedWaiting, rank);
     }
 
-    public WaitingResponse postponeWaiting(Long memberId){
+    public WaitingResponse postponeWaiting(Long memberId) {
         Member member = getMemberEntity(memberId);
         Waiting waiting = getWaitingEntity(member);
 
@@ -73,6 +73,7 @@ public class WaitingService {
 
         return toWaitingResponse(waiting, rank);
     }
+
     private void validateIfMemberWaitingExists(Member member) {
         if (waitingRepository.existsByMember(member)) {
             throw new BadRequestCustomException(EXISTING_MEMBER_WAITING);
@@ -93,7 +94,7 @@ public class WaitingService {
         return shop;
     }
 
-    public Waiting getWaitingEntity(Member member){
+    public Waiting getWaitingEntity(Member member) {
         return waitingRepository.findByMember(member).orElseThrow(
             () -> new NotFoundCustomException(NOT_EXIST_WAITING)
         );

--- a/src/main/java/com/prgrms/catchtable/waiting/service/WaitingService.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/service/WaitingService.java
@@ -23,6 +23,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -60,6 +61,7 @@ public class WaitingService {
         return toWaitingResponse(savedWaiting, rank);
     }
 
+    @Transactional
     public WaitingResponse postponeWaiting(Long memberId) {
         Member member = getMemberEntity(memberId);
         Waiting waiting = getWaitingEntity(member);
@@ -70,7 +72,6 @@ public class WaitingService {
         waitingLineRepository.postpone(shop.getId(), waiting.getId());
         Long rank = waitingLineRepository.findRank(shop.getId(), waiting.getId());
         waiting.decreasePostponeRemainingCount();
-
         return toWaitingResponse(waiting, rank);
     }
 
@@ -95,7 +96,7 @@ public class WaitingService {
     }
 
     public Waiting getWaitingEntity(Member member) {
-        return waitingRepository.findByMember(member).orElseThrow(
+        return waitingRepository.findByMemberWithShop(member).orElseThrow(
             () -> new NotFoundCustomException(NOT_EXIST_WAITING)
         );
     }

--- a/src/main/java/com/prgrms/catchtable/waiting/service/WaitingService.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/service/WaitingService.java
@@ -3,7 +3,7 @@ package com.prgrms.catchtable.waiting.service;
 import static com.prgrms.catchtable.common.exception.ErrorCode.EXISTING_MEMBER_WAITING;
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_MEMBER;
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_SHOP;
-import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toCreateWaitingResponse;
+import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toWaitingResponse;
 import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toWaiting;
 
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
@@ -59,7 +59,7 @@ public class WaitingService {
         waitingLineRepository.save(shopId, waiting.getId());
         Long rank = waitingLineRepository.findRank(shopId, waiting.getId());
 
-        return toCreateWaitingResponse(savedWaiting, rank);
+        return toWaitingResponse(savedWaiting, rank);
     }
 
 

--- a/src/test/java/com/prgrms/catchtable/waiting/controller/WaitingControllerDocsTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/controller/WaitingControllerDocsTest.java
@@ -37,12 +37,13 @@ class WaitingControllerDocsTest extends RestDocsSupport {
             .builder()
             .peopleCount(2).build();
         WaitingResponse response = WaitingResponse.builder()
-            .createdWaitingId(201L)
+            .waitingId(201L)
             .shopId(1L)
             .shopName("shop1")
             .waitingNumber(324)
             .rank(20L)
             .peopleCount(2)
+            .remainingPostponeCount(2)
             .build();
 
         given(waitingService.createWaiting(1L, 1L, request)).willReturn(response);
@@ -59,7 +60,7 @@ class WaitingControllerDocsTest extends RestDocsSupport {
                         .description("인원수")
                 ),
                 responseFields(
-                    fieldWithPath("createdWaitingId").type(JsonFieldType.NUMBER)
+                    fieldWithPath("waitingId").type(JsonFieldType.NUMBER)
                         .description("생성된 웨이팅 아이디"),
                     fieldWithPath("shopId").type(JsonFieldType.NUMBER)
                         .description("상점 아이디"),
@@ -70,7 +71,9 @@ class WaitingControllerDocsTest extends RestDocsSupport {
                     fieldWithPath("waitingNumber").type(JsonFieldType.NUMBER)
                         .description("웨이팅 고유 번호"),
                     fieldWithPath("rank").type(JsonFieldType.NUMBER)
-                        .description("웨이팅 순서")
+                        .description("웨이팅 순서"),
+                    fieldWithPath("remainingPostponeCount").type(JsonFieldType.NUMBER)
+                        .description("대기 지연 잔여 횟수")
                 )
             ));
 

--- a/src/test/java/com/prgrms/catchtable/waiting/controller/WaitingControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/controller/WaitingControllerTest.java
@@ -18,6 +18,9 @@ import com.prgrms.catchtable.waiting.dto.CreateWaitingRequest;
 import com.prgrms.catchtable.waiting.repository.WaitingRepository;
 import com.prgrms.catchtable.waiting.repository.waitingline.WaitingLineRepository;
 import java.util.List;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -26,7 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.transaction.annotation.Transactional;
-
+@Slf4j
 @Transactional
 class WaitingControllerTest extends BaseIntegrationTest {
 
@@ -135,5 +138,8 @@ class WaitingControllerTest extends BaseIntegrationTest {
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.message").value("이미 맨뒤라 웨이팅을 미룰 수 없습니다."))
             .andDo(MockMvcResultHandlers.print());
+//        Waiting waiting = waitingRepository.findById(waiting3.getId()).orElse(null);
+//        Assertions.assertThat(waiting.getPostponeRemainingCount()).isEqualTo(2);
     }
+
 }

--- a/src/test/java/com/prgrms/catchtable/waiting/controller/WaitingControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/controller/WaitingControllerTest.java
@@ -1,7 +1,8 @@
 package com.prgrms.catchtable.waiting.controller;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -113,9 +114,9 @@ class WaitingControllerTest extends BaseIntegrationTest {
 
     @DisplayName("웨이팅 지연 API를 호출할 수 있다.")
     @Test
-    void postponeWaiting() throws Exception{
+    void postponeWaiting() throws Exception {
         //when, then
-        mockMvc.perform(patch("/waitings/{memberId}",member2.getId())
+        mockMvc.perform(patch("/waitings/{memberId}", member2.getId())
                 .contentType(APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.shopId").value(shop.getId()))
@@ -129,7 +130,7 @@ class WaitingControllerTest extends BaseIntegrationTest {
     @DisplayName("맨 뒤의 멤버가 웨이팅 지연 API 호출 시 예외 반환")
     @Test
     void postponeWaiting_fails() throws Exception {
-        mockMvc.perform(patch("/waitings/{memberId}",member3.getId())
+        mockMvc.perform(patch("/waitings/{memberId}", member3.getId())
                 .contentType(APPLICATION_JSON))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.message").value("이미 맨뒤라 웨이팅을 미룰 수 없습니다."))

--- a/src/test/java/com/prgrms/catchtable/waiting/controller/WaitingControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/controller/WaitingControllerTest.java
@@ -18,9 +18,7 @@ import com.prgrms.catchtable.waiting.dto.CreateWaitingRequest;
 import com.prgrms.catchtable.waiting.repository.WaitingRepository;
 import com.prgrms.catchtable.waiting.repository.waitingline.WaitingLineRepository;
 import java.util.List;
-import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -30,6 +28,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.transaction.annotation.Transactional;
+
 @Slf4j
 @Transactional
 class WaitingControllerTest extends BaseIntegrationTest {
@@ -147,7 +146,7 @@ class WaitingControllerTest extends BaseIntegrationTest {
     @DisplayName("대기 지연 잔여 횟수를 소진 시, 더이상 지연이 불가하므로 예외를 반환한다.")
     @Test
     void postponeWaiting_fails2() throws Exception {
-        ReflectionTestUtils.setField(waiting1,"remainingPostponeCount",0);
+        ReflectionTestUtils.setField(waiting1, "remainingPostponeCount", 0);
         mockMvc.perform(patch("/waitings/{memberId}", member1.getId())
                 .contentType(APPLICATION_JSON))
             .andExpect(status().isBadRequest())

--- a/src/test/java/com/prgrms/catchtable/waiting/controller/WaitingControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/controller/WaitingControllerTest.java
@@ -1,7 +1,7 @@
 package com.prgrms.catchtable.waiting.controller;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -111,4 +111,28 @@ class WaitingControllerTest extends BaseIntegrationTest {
 
     }
 
+    @DisplayName("웨이팅 지연 API를 호출할 수 있다.")
+    @Test
+    void postponeWaiting() throws Exception{
+        //when, then
+        mockMvc.perform(patch("/waitings/{memberId}",member2.getId())
+                .contentType(APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.shopId").value(shop.getId()))
+            .andExpect(jsonPath("$.shopName").value(shop.getName()))
+            .andExpect(jsonPath("$.rank").value(3))
+            .andExpect(jsonPath("$.waitingNumber").value(waiting2.getWaitingNumber()))
+            .andExpect(jsonPath("$.peopleCount").value(waiting2.getPeopleCount()))
+            .andDo(MockMvcResultHandlers.print());
+    }
+
+    @DisplayName("맨 뒤의 멤버가 웨이팅 지연 API 호출 시 예외 반환")
+    @Test
+    void postponeWaiting_fails() throws Exception {
+        mockMvc.perform(patch("/waitings/{memberId}",member3.getId())
+                .contentType(APPLICATION_JSON))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("이미 맨뒤라 웨이팅을 미룰 수 없습니다."))
+            .andDo(MockMvcResultHandlers.print());
+    }
 }

--- a/src/test/java/com/prgrms/catchtable/waiting/service/WaitingServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/service/WaitingServiceTest.java
@@ -3,6 +3,7 @@ package com.prgrms.catchtable.waiting.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
@@ -18,6 +19,7 @@ import com.prgrms.catchtable.waiting.repository.WaitingRepository;
 import com.prgrms.catchtable.waiting.repository.waitingline.WaitingLineRepository;
 import java.time.LocalTime;
 import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -69,6 +71,31 @@ class WaitingServiceTest {
             () -> assertThat(response.peopleCount()).isEqualTo(2),
             () -> assertThat(response.rank()).isEqualTo(1L),
             () -> assertThat(response.waitingNumber()).isEqualTo(1)
+        );
+    }
+
+    @DisplayName("대기 지연을 할 수 있다.")
+    @Test
+    void postponeWaiting() {
+        //given
+        Shop shop = mock(Shop.class);
+        Member member = mock(Member.class);
+        Waiting waiting = mock(Waiting.class);
+
+        given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+        given(waitingRepository.findByMember(member)).willReturn(Optional.of(waiting));
+        given(waiting.getShop()).willReturn(shop);
+        given(waitingLineRepository.findRank(anyLong(), anyLong())).willReturn(3L);
+        doNothing().when(waiting).validatePostponeRemainingCount();
+        doNothing().when(waiting).decreasePostponeRemainingCount();
+
+        //when
+        WaitingResponse response = waitingService.postponeWaiting(1L);
+        //then
+        assertAll(
+            assertThat(response.peopleCount())::isNotNull,
+            () -> assertThat(response.rank()).isNotNull(),
+            assertThat(response.waitingNumber())::isNotNull
         );
     }
 }

--- a/src/test/java/com/prgrms/catchtable/waiting/service/WaitingServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/service/WaitingServiceTest.java
@@ -83,7 +83,7 @@ class WaitingServiceTest {
         Waiting waiting = mock(Waiting.class);
 
         given(memberRepository.findById(1L)).willReturn(Optional.of(member));
-        given(waitingRepository.findByMember(member)).willReturn(Optional.of(waiting));
+        given(waitingRepository.findByMemberWithShop(member)).willReturn(Optional.of(waiting));
         given(waiting.getShop()).willReturn(shop);
         given(waitingLineRepository.findRank(anyLong(), anyLong())).willReturn(3L);
         doNothing().when(waiting).validatePostponeRemainingCount();


### PR DESCRIPTION
### ⛏ 작업 상세 내용

- 대기 지연 API 구현
- API 응답 모두 동일하게 가져가도록 함
  - 추후 노션에 반영 예정
- waiting 생성 로직 수정
  - shop을 가져올 때 엔티티 내에서 영업 시간 검증하도록 함
- 대기 지연 service, controller test 작성
- 대기 생성 controller test 리팩토링

### 📝 작업 요약

- 대기 지연 API 작성 및 기존 대기 생성 비즈니스 로직 리팩토링

### **☑️** 중점적으로 리뷰 할 부분

- 대기 지연 비즈니스 로직
- 대기 지연 service test
