### PR TITLE
feat : 예약 수정 로직 추가

### DIFF
--- a/src/main/java/com/prgrms/catchtable/reservation/domain/ReservationTime.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/domain/ReservationTime.java
@@ -58,4 +58,12 @@ public class ReservationTime {
     public void insertShop(Shop shop) {
         this.shop = shop;
     }
+
+    public void setOccupiedTrue() {
+        this.isOccupied = true;
+    }
+
+    public void setOccupiedFalse() {
+        this.isOccupied = false;
+    }
 }

--- a/src/main/java/com/prgrms/catchtable/reservation/service/MemberReservationService.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/service/MemberReservationService.java
@@ -139,7 +139,7 @@ public class MemberReservationService {
     }
 
     private void validateIsPreOccupied(ReservationTime reservationTime) {
-        if (reservationTime.isPreOccupied()) {
+        if (reservationTime.isOccupied()) {
             reservationLockRepository.unlock(reservationTime.getId());
             throw new BadRequestCustomException(ALREADY_PREOCCUPIED_RESERVATION_TIME);
         }

--- a/src/main/java/com/prgrms/catchtable/reservation/service/MemberReservationService.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/service/MemberReservationService.java
@@ -113,9 +113,9 @@ public class MemberReservationService {
 
         validateIsPreOccupied(reservationTime); // 예약시간이 선점되었는 지 확인
 
-        reservation.getReservationTime().setOccupiedFalse(); // 기존 예약의 예약시간 예약가능으로 변경
-
         validateIsOccupied(reservationTime); // 예약시간이 이미 차지되었는 지 확인
+
+        reservation.getReservationTime().setOccupiedFalse(); // 기존 예약의 예약시간 예약가능으로 변경
 
         reservation.modifyReservation(reservationTime,
             request.peopleCount()); // 예약 필드 값 수정하는 엔티티의 메소드
@@ -139,7 +139,7 @@ public class MemberReservationService {
     }
 
     private void validateIsPreOccupied(ReservationTime reservationTime) {
-        if (reservationTime.isOccupied()) {
+        if (reservationTime.isPreOccupied()) {
             reservationLockRepository.unlock(reservationTime.getId());
             throw new BadRequestCustomException(ALREADY_PREOCCUPIED_RESERVATION_TIME);
         }

--- a/src/main/java/com/prgrms/catchtable/reservation/service/MemberReservationService.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/service/MemberReservationService.java
@@ -113,6 +113,8 @@ public class MemberReservationService {
 
         validateIsPreOccupied(reservationTime); // 예약시간이 선점되었는 지 확인
 
+        reservation.getReservationTime().setOccupiedFalse(); // 기존 예약의 예약시간 예약가능으로 변경
+
         validateIsOccupied(reservationTime); // 예약시간이 이미 차지되었는 지 확인
 
         reservation.modifyReservation(reservationTime,

--- a/src/main/java/com/prgrms/catchtable/reservation/service/OwnerReservationService.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/service/OwnerReservationService.java
@@ -40,7 +40,7 @@ public class OwnerReservationService {
     ) {
         ReservationStatus modifyStatus = request.status(); // 요청으로 들어온 변경하려는 예약상태 추출
 
-        if(modifyStatus == COMPLETED){ // 취소, 노쇼 처리가 아닌 경우 예외
+        if (modifyStatus == COMPLETED) { // 취소, 노쇼 처리가 아닌 경우 예외
             throw new BadRequestCustomException(ALREADY_COMPLETED_RESERVATION);
         }
 

--- a/src/test/java/com/prgrms/catchtable/reservation/controller/MemberReservationControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/controller/MemberReservationControllerTest.java
@@ -130,6 +130,7 @@ class MemberReservationControllerTest extends BaseIntegrationTest {
     @DisplayName("예약 수정 api 호출에 성공한다.")
     void modifyReservation() throws Exception {
         ReservationTime reservationTime = reservationTimeRepository.findAll().get(0);
+        reservationTime.setOccupiedTrue();
         Reservation reservation = ReservationFixture.getReservation(reservationTime);
         Reservation savedReservation = reservationRepository.save(reservation);
         /**
@@ -152,7 +153,7 @@ class MemberReservationControllerTest extends BaseIntegrationTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.date").value(modifyReservationTime.getTime().toString()))
             .andExpect(jsonPath("$.peopleCount").value(request.peopleCount()));
-
+        assertThat(reservationTime.isOccupied()).isFalse(); // 기존 예약 시간 예약가능으로 변경되었는 지 검증
         assertThat(savedReservation.getReservationTime()).isEqualTo(
             modifyReservationTime); // 수정하려는 예약시간으로 예약이 변경되었는 지 검증
         assertThat(savedReservation.getReservationTime().isOccupied()).isFalse();

--- a/src/test/java/com/prgrms/catchtable/reservation/service/MemberReservationServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/service/MemberReservationServiceTest.java
@@ -193,7 +193,8 @@ class MemberReservationServiceTest {
 
         //then
         assertAll(
-            () -> assertThat(reservationTime.isOccupied()).isFalse(), // 수정 후 기존 예약시간이 예약가능으로 바뀌었는 지 검증
+            () -> assertThat(reservationTime.isOccupied()).isFalse(),
+            // 수정 후 기존 예약시간이 예약가능으로 바뀌었는 지 검증
             () -> assertThat(response.date()).isEqualTo(modifyTime.getTime()),
             () -> assertThat(response.peopleCount()).isEqualTo(reservation.getPeopleCount()),
             () -> assertThat(reservation.getReservationTime()).isEqualTo(modifyTime)

--- a/src/test/java/com/prgrms/catchtable/reservation/service/MemberReservationServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/service/MemberReservationServiceTest.java
@@ -172,6 +172,7 @@ class MemberReservationServiceTest {
 
         ReservationTime reservationTime = ReservationFixture.getReservationTimeNotPreOccupied();
         reservationTime.insertShop(shop);
+        reservationTime.setOccupiedTrue(); // 수정 전 예약시간은 예약이 차있는 걸로 되어있어야함
         ReflectionTestUtils.setField(reservationTime, "id", 1L); // 수정 전 예약시간 객체 -> Id : 1
 
         ReservationTime modifyTime = ReservationFixture.getAnotherReservationTimeNotPreOccupied();
@@ -192,6 +193,7 @@ class MemberReservationServiceTest {
 
         //then
         assertAll(
+            () -> assertThat(reservationTime.isOccupied()).isFalse(), // 수정 후 기존 예약시간이 예약가능으로 바뀌었는 지 검증
             () -> assertThat(response.date()).isEqualTo(modifyTime.getTime()),
             () -> assertThat(response.peopleCount()).isEqualTo(reservation.getPeopleCount()),
             () -> assertThat(reservation.getReservationTime()).isEqualTo(modifyTime)


### PR DESCRIPTION
close #63 
### ⛏ 작업 상세 내용

- 기존에 예약 수정 로직에서 수정 전의 예약시간을 예약가능으로 바꾸는 로직이 없어서 추가
- 로직 추가에 따른 서비스, 컨트롤러 다시 테스트 (수정에 관한 것만)
- 예약시간의 isOccupied 필드 설정하는 메소드 예약시간 엔티티에 추가
    - 기존에는 reverseOccupied()로 현재값의 반대값을 넣어주는 메소드를 활용했는데 이번에 추가한 메소드로 전부 리팩토링 예정

### 📝 작업 요약

- 예약 수정 비즈니스 로직 추가

### **☑️** 중점적으로 리뷰 할 부분
