### PR TITLE
feat : 알림 서비스 로직 구현(Slack API)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,9 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    implementation group: 'org.json', name: 'json', version: '20231013'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/prgrms/catchtable/common/NotificationContent.java
+++ b/src/main/java/com/prgrms/catchtable/common/NotificationContent.java
@@ -1,0 +1,23 @@
+package com.prgrms.catchtable.common;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum NotificationContent {
+    RESERVATION_COMPLETED("예약이 완료되었습니다"),
+    RESERVATION_ONE_HOUR_LEFT("예약 시간 1시간 전입니다."),
+    RESERVATION_TIME_TO_ENTER("예약시간이 되었습니다"),
+    WAITING_REGISTER_COMPLETED("웨이팅 등록이 완료되었습니다"),
+    WAITING_RANK_THIRD("웨이팅 순서가 3번째가 되었습니다"),
+    WAITING_TIME_TO_ENTER("웨이팅이 끝났습니다. 입장 부탁드립니다."),
+    WAITING_CANCELLED_AUTOMATICALLY("웨이팅이 자동으로 취소되었습니다.");
+
+    private final String message;
+
+
+
+
+
+}

--- a/src/main/java/com/prgrms/catchtable/common/exception/ErrorCode.java
+++ b/src/main/java/com/prgrms/catchtable/common/exception/ErrorCode.java
@@ -28,7 +28,9 @@ public enum ErrorCode {
     CAN_NOT_ENTRY("웨이팅을 입장 처리할 수 없습니다"),
     WAITING_DOES_NOT_EXIST("웨이팅이 존재하지 않습니다"),
     SHOP_NOT_RUNNING("가게가 영업시간이 아닙니다."),
-    INTERNAL_SERVER_ERROR("내부 서버 오류입니다.");
+    INTERNAL_SERVER_ERROR("내부 서버 오류입니다."),
+
+    SLACK_ID_IS_WRONG("요청한 슬랙 Id를 찾을 수 없거나 잘못 되었습니다");
 
     private final String message;
 }

--- a/src/main/java/com/prgrms/catchtable/notification/controller/NotificationController.java
+++ b/src/main/java/com/prgrms/catchtable/notification/controller/NotificationController.java
@@ -1,0 +1,19 @@
+package com.prgrms.catchtable.notification.controller;
+
+import com.prgrms.catchtable.notification.dto.request.SendMessageRequest;
+import com.prgrms.catchtable.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class NotificationController {
+    private final NotificationService notificationService;
+
+    @GetMapping("/test")
+    public void test(@RequestBody SendMessageRequest request){
+        notificationService.sendMessageToMemberAndSave(request);
+    }
+}

--- a/src/main/java/com/prgrms/catchtable/notification/domain/NotificationOwner.java
+++ b/src/main/java/com/prgrms/catchtable/notification/domain/NotificationOwner.java
@@ -36,7 +36,8 @@ public class NotificationOwner extends BaseEntity {
     private Owner owner;
 
     @Builder
-    public NotificationOwner(String message) {
+    public NotificationOwner(Owner owner, String message) {
+        this.owner = owner;
         this.message = message;
     }
 }

--- a/src/main/java/com/prgrms/catchtable/notification/dto/request/SendMessageRequest.java
+++ b/src/main/java/com/prgrms/catchtable/notification/dto/request/SendMessageRequest.java
@@ -1,0 +1,7 @@
+package com.prgrms.catchtable.notification.dto.request;
+
+import com.prgrms.catchtable.common.NotificationContent;
+
+public record SendMessageRequest(NotificationContent content) {
+
+}

--- a/src/main/java/com/prgrms/catchtable/notification/repository/NotificationMemberRepository.java
+++ b/src/main/java/com/prgrms/catchtable/notification/repository/NotificationMemberRepository.java
@@ -1,8 +1,10 @@
 package com.prgrms.catchtable.notification.repository;
 
+import com.prgrms.catchtable.member.domain.Member;
 import com.prgrms.catchtable.notification.domain.NotificationMember;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationMemberRepository extends JpaRepository<NotificationMember, Long> {
-
+    Optional<NotificationMember> findByMember(Member member);
 }

--- a/src/main/java/com/prgrms/catchtable/notification/repository/NotificationOwnerRepository.java
+++ b/src/main/java/com/prgrms/catchtable/notification/repository/NotificationOwnerRepository.java
@@ -1,8 +1,10 @@
 package com.prgrms.catchtable.notification.repository;
 
 import com.prgrms.catchtable.notification.domain.NotificationOwner;
+import com.prgrms.catchtable.owner.domain.Owner;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationOwnerRepository extends JpaRepository<NotificationOwner, Long> {
-
+    Optional<NotificationOwner> findByOwner(Owner owner);
 }

--- a/src/main/java/com/prgrms/catchtable/notification/service/NotificationService.java
+++ b/src/main/java/com/prgrms/catchtable/notification/service/NotificationService.java
@@ -1,0 +1,141 @@
+package com.prgrms.catchtable.notification.service;
+
+import static com.prgrms.catchtable.common.exception.ErrorCode.*;
+import static org.springframework.http.HttpMethod.*;
+
+import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
+import com.prgrms.catchtable.member.domain.Member;
+import com.prgrms.catchtable.member.repository.MemberRepository;
+import com.prgrms.catchtable.notification.domain.NotificationMember;
+import com.prgrms.catchtable.notification.domain.NotificationOwner;
+import com.prgrms.catchtable.notification.dto.request.SendMessageRequest;
+import com.prgrms.catchtable.notification.repository.NotificationMemberRepository;
+import com.prgrms.catchtable.notification.repository.NotificationOwnerRepository;
+import com.prgrms.catchtable.owner.domain.Owner;
+import com.prgrms.catchtable.owner.repository.OwnerRepository;
+import lombok.RequiredArgsConstructor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationService {
+
+    @Value("${slack.token}")
+    private String slackToken;
+
+    private final NotificationMemberRepository notificationMemberRepository;
+    private final NotificationOwnerRepository notificationOwnerRepository;
+    private final MemberRepository memberRepository; // 추후 삭제 예정
+    private final OwnerRepository ownerRepository; // 추후 삭제 예정
+    private JSONObject jsonObject;
+
+    public void sendMessageToMemberAndSave(SendMessageRequest request) {
+        String url = "https://slack.com/api/chat.postMessage"; // slack 메세지를 보내도록 요청하는 Slack API
+        // member 예제 데이터
+        Member member = Member.builder()
+            .email("dlswns661035@gmail.com") // 이 부분 이메일 바꿔서 하면 해당 이메일의 슬랙 개인으로 dm 보냄
+            .build();
+
+        String email = member.getEmail();
+        String message = request.content().getMessage();
+        String slackId = getSlackIdByEmail(email); // 이메일을 통해 사용자의 슬랙 고유 ID 추출
+
+        requestToSendMessage(slackId, message); // 알림 요청 보내는 함수 호출
+
+
+        NotificationMember notification = NotificationMember.builder()
+            .member(member)
+            .message(message)
+            .build();
+        memberRepository.save(member); // 추후 삭제 예정
+        notificationMemberRepository.save(notification); // 해당 사용자의 알림 생성 후 저장
+
+    }
+
+    public void sendMessageToOwnerAndSave(SendMessageRequest request) {
+        String url = "https://slack.com/api/chat.postMessage"; // slack 메세지를 보내도록 요청하는 Slack API
+        //Owner 예제 데이터
+        Owner owner = Owner.builder()
+            .email("dlswns661035@gmail.com") // 이 부분 이메일 바꿔서 하면 해당 이메일의 슬랙 개인으로 dm 보냄
+            .build();
+
+        String email = owner.getEmail();
+        String message = request.content().getMessage();
+        String slackId = getSlackIdByEmail(email);
+
+        requestToSendMessage(slackId, message);
+
+        NotificationOwner notification = NotificationOwner.builder()
+            .owner(owner)
+            .message(message)
+            .build();
+        ownerRepository.save(owner); //추후 삭제 예정
+        notificationOwnerRepository.save(notification);
+    }
+
+    private void requestToSendMessage(String slackId, String message){
+        String url = "https://slack.com/api/chat.postMessage";
+
+        // 헤더에 캐치테이블 클론 슬랙 토큰 삽입
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + slackToken);
+        headers.add("Content-type", "application/json; charset=utf-8");
+
+
+
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("channel", slackId); // 채널 필드에 사용자의 슬랙 고유 ID
+        jsonObject.put("text", message); // 메세지 필드에 메세지
+        String body = jsonObject.toString();
+
+        HttpEntity<String> requestEntity = new HttpEntity<>(body, headers);
+        RestTemplate restTemplate = new RestTemplate();
+
+        ResponseEntity<String> response = restTemplate.exchange(
+            url,
+            POST,
+            requestEntity,
+            String.class
+        );// post로 위에서 만든 Json body 전송 요청
+
+        jsonObject = new JSONObject(response.getBody());
+        String result = jsonObject.get("ok").toString();
+
+        if(result.equals("false")){ // 알림 요청 보낸 후 응답의 ok필드 값이 false면 슬랙아이디가 잘못되었다는 것
+            throw new BadRequestCustomException(SLACK_ID_IS_WRONG);
+        }
+
+        // ok 필드값이 true면 알림 전송 완료 된것임
+    }
+
+    public String getSlackIdByEmail(String email) {
+        String url = "https://slack.com/api/users.lookupByEmail?email=".concat(email);
+
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + slackToken);
+        headers.add("Content-type", "application/x-www-form-urlencoded");
+
+        RestTemplate restTemplate = new RestTemplate();
+        HttpEntity<String> requestEntity = new HttpEntity<>(headers);
+        ResponseEntity<String> responseEntity = restTemplate.exchange(
+            url,
+            GET,
+            requestEntity,
+            String.class
+        );
+        jsonObject = new JSONObject(responseEntity.getBody());
+        JSONObject profile = jsonObject.getJSONObject("user");
+
+        return profile.get("id").toString();
+    }
+}

--- a/src/main/java/com/prgrms/catchtable/owner/domain/Owner.java
+++ b/src/main/java/com/prgrms/catchtable/owner/domain/Owner.java
@@ -35,6 +35,9 @@ public class Owner extends BaseEntity {
     @Column(name = "owner_name")
     private String name;
 
+    @Column(name = "email")
+    private String email;
+
     @Column(name = "phone_number")
     private String phoneNumber;
 
@@ -50,8 +53,9 @@ public class Owner extends BaseEntity {
     private Shop shop;
 
     @Builder
-    public Owner(String name, String phoneNumber, Gender gender, LocalDate dateBirth) {
+    public Owner(String name, String email, String phoneNumber, Gender gender, LocalDate dateBirth) {
         this.name = name;
+        this.email = email;
         this.phoneNumber = phoneNumber;
         this.gender = gender;
         this.dateBirth = dateBirth;


### PR DESCRIPTION
close #69 
### ⛏ 작업 상세 내용

- NotificationContent
   - 알림 관련 메세지들을 정의해놓았습니다. 메세지 보낼때 활용합니다.
- NotificationService
    - 캐치테이블 클론 슬랙을 새로 만들어서 oauth token을 받아서 yaml 파일에 추가하였고 노션에 반영하겠습니다. (알림 요청 보낼 때 헤더에 해당 oauth token이 있어야 해서 추가했습니다)
    - Slack API 활용 개인에게 dm을 보내는 기능이 있습니다.
    - 로그인한 회원의 이메일을 통해 해당 회원의 slack 고유 id를 추출하고 요청 body에 고유 Id와 메세지를 보내면 dm이 갑니다.
    - 아직 Member를 추출할 수 없어 메세지 보내는 메소드에 이메일이 제걸로 되어있는데 테스트 시 본인 걸로 바꿔서 하시면 됩니다.
    - 캐치테이블 클론 슬랙 초청 수락 하신 후 테스트 할 수 있습니다.
- NotificationController
   - 테스트용 api 하나가 있습니다. 알림 보내는 로직은 서비스단 안에서 사용하기 때문에 필요없지만 실제 슬랙 연동해서 테스트 해보시라고 만들었습니다. 포스트맨 활용 시 헤더에 yaml에 있는 slack token을 Bearer로 넣고 예시 요청 body는 다음과 같습니다.
```java
{
    "content" : "RESERVATION_COMPLETED"
}
```
- NotificationMemberRepository, NotificationOwnerRepository
    - 개인 알림 조회용 쿼리 추가했습니다. 추후 알림 조회 api 구현시 활용할 예정입니다.
### 📝 작업 요약

- 알림 서비스 구현 완료

### **☑️** 중점적으로 리뷰 할 부분

- 테스트 코드는 아직 안 짰습니다.
- 알림 코드 로직
- 코드 가독성
- 머지 되면 알림 보내는 메소드를 각자 필요한 비즈니스 로직 내에서 호출하시면 됩니다.
