### PR TITLE
feat : 회원의 예약 전체조회 api 추가 및 테스트

### DIFF
--- a/src/main/java/com/prgrms/catchtable/reservation/controller/MemberReservationController.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/controller/MemberReservationController.java
@@ -53,7 +53,7 @@ public class MemberReservationController {
     }
 
     @GetMapping
-    public ResponseEntity<List<GetAllReservationResponse>> getAllReservation(){
+    public ResponseEntity<List<GetAllReservationResponse>> getAllReservation() {
         return ResponseEntity.ok(memberReservationService.getAllReservation());
     }
 }

--- a/src/main/java/com/prgrms/catchtable/reservation/controller/MemberReservationController.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/controller/MemberReservationController.java
@@ -4,11 +4,14 @@ import com.prgrms.catchtable.reservation.dto.request.CreateReservationRequest;
 import com.prgrms.catchtable.reservation.dto.request.ModifyReservationRequest;
 import com.prgrms.catchtable.reservation.dto.response.CancelReservationResponse;
 import com.prgrms.catchtable.reservation.dto.response.CreateReservationResponse;
+import com.prgrms.catchtable.reservation.dto.response.GetAllReservationResponse;
 import com.prgrms.catchtable.reservation.dto.response.ModifyReservationResponse;
 import com.prgrms.catchtable.reservation.service.MemberReservationService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -47,5 +50,10 @@ public class MemberReservationController {
     public ResponseEntity<CancelReservationResponse> cancelReservation(
         @PathVariable("reservationId") Long reservationId) {
         return ResponseEntity.ok(memberReservationService.cancelReservation(reservationId));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<GetAllReservationResponse>> getAllReservation(){
+        return ResponseEntity.ok(memberReservationService.getAllReservation());
     }
 }

--- a/src/test/java/com/prgrms/catchtable/owner/controller/OwnerControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/owner/controller/OwnerControllerTest.java
@@ -1,6 +1,6 @@
 package com.prgrms.catchtable.owner.controller;
 
-import static org.springframework.http.MediaType.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

--- a/src/test/java/com/prgrms/catchtable/owner/fixture/OwnerFixture.java
+++ b/src/test/java/com/prgrms/catchtable/owner/fixture/OwnerFixture.java
@@ -1,15 +1,14 @@
 package com.prgrms.catchtable.owner.fixture;
 
+import static com.prgrms.catchtable.member.domain.Gender.MALE;
+
 import com.prgrms.catchtable.common.data.shop.ShopData;
-import com.prgrms.catchtable.member.domain.Gender;
 import com.prgrms.catchtable.owner.domain.Owner;
 import com.prgrms.catchtable.owner.dto.request.JoinOwnerRequest;
 import com.prgrms.catchtable.owner.dto.request.LoginOwnerRequest;
 import com.prgrms.catchtable.shop.domain.Shop;
 import java.time.LocalDate;
 import org.springframework.test.util.ReflectionTestUtils;
-
-import static com.prgrms.catchtable.member.domain.Gender.MALE;
 
 
 public class OwnerFixture {
@@ -29,7 +28,7 @@ public class OwnerFixture {
         return owner;
     }
 
-    public static JoinOwnerRequest getJoinOwnerRequest(String email, String password){
+    public static JoinOwnerRequest getJoinOwnerRequest(String email, String password) {
         return JoinOwnerRequest.builder()
             .name("ownerA")
             .email(email)
@@ -40,7 +39,7 @@ public class OwnerFixture {
             .build();
     }
 
-    public static LoginOwnerRequest getLoginOwnerRequest(String email, String password){
+    public static LoginOwnerRequest getLoginOwnerRequest(String email, String password) {
         return LoginOwnerRequest.builder()
             .email(email)
             .password(password)

--- a/src/test/java/com/prgrms/catchtable/owner/service/OwnerServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/owner/service/OwnerServiceTest.java
@@ -1,6 +1,7 @@
 package com.prgrms.catchtable.owner.service;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -105,7 +106,8 @@ class OwnerServiceTest {
     @DisplayName("비밀번호가 다르면 로그인을 실패한다.")
     void loginFailurePassword() {
         //given
-        LoginOwnerRequest loginOwnerRequest = OwnerFixture.getLoginOwnerRequest(email, wrongPassword);
+        LoginOwnerRequest loginOwnerRequest = OwnerFixture.getLoginOwnerRequest(email,
+            wrongPassword);
         String encodePassword = passwordEncoder.encode(password);
 
         //when

--- a/src/test/java/com/prgrms/catchtable/reservation/controller/MemberReservationControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/controller/MemberReservationControllerTest.java
@@ -5,6 +5,7 @@ import static com.prgrms.catchtable.reservation.domain.ReservationStatus.CANCELL
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -170,6 +171,22 @@ class MemberReservationControllerTest extends BaseIntegrationTest {
                 .contentType(APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.status").value(CANCELLED.toString()));
+    }
+
+    @Test
+    @DisplayName("회원은 자신의 예약내역을 조회할 수 있다.")
+    void getAllReservation() throws Exception {
+        Reservation reservation = ReservationFixture.getReservation(
+            reservationTimeRepository.findAll().get(0));
+
+        Reservation savedReservation = reservationRepository.save(reservation);
+
+        mockMvc.perform(get("/reservations"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].reservationId").value(savedReservation.getId()))
+            .andExpect(jsonPath("$[0].date").value(savedReservation.getReservationTime().getTime().toString()))
+            .andExpect(jsonPath("$[0].peopleCount").value(savedReservation.getPeopleCount()))
+            .andExpect(jsonPath("$[0].shopName").value(savedReservation.getShop().getName()));
     }
 
 }

--- a/src/test/java/com/prgrms/catchtable/reservation/controller/MemberReservationControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/controller/MemberReservationControllerTest.java
@@ -184,7 +184,8 @@ class MemberReservationControllerTest extends BaseIntegrationTest {
         mockMvc.perform(get("/reservations"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$[0].reservationId").value(savedReservation.getId()))
-            .andExpect(jsonPath("$[0].date").value(savedReservation.getReservationTime().getTime().toString()))
+            .andExpect(jsonPath("$[0].date").value(
+                savedReservation.getReservationTime().getTime().toString()))
             .andExpect(jsonPath("$[0].peopleCount").value(savedReservation.getPeopleCount()))
             .andExpect(jsonPath("$[0].shopName").value(savedReservation.getShop().getName()));
     }

--- a/src/test/java/com/prgrms/catchtable/reservation/controller/OwnerReservationControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/controller/OwnerReservationControllerTest.java
@@ -91,11 +91,13 @@ class OwnerReservationControllerTest extends BaseIntegrationTest {
     @Test
     @DisplayName("점주는 예약된 정보들을 전체 조회할 수 있다.")
     void getAllReservation() throws Exception {
-        List<Reservation> reservations = reservationRepository.findAllWithReservationTimeAndShop();
+        Owner owner = ownerRepository.findAll().get(0);
+
+        List<Reservation> reservations = reservationRepository.findAllWithReservationTimeAndShopByShopId(owner.getShop().getId());
         Reservation reservation1 = reservations.get(0);
         Reservation reservation2 = reservations.get(1);
 
-        Owner owner = ownerRepository.findAll().get(0);
+
 
         mockMvc.perform(get("/owners/shop")
                 .contentType(APPLICATION_JSON)

--- a/src/test/java/com/prgrms/catchtable/reservation/controller/OwnerReservationControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/controller/OwnerReservationControllerTest.java
@@ -93,11 +93,10 @@ class OwnerReservationControllerTest extends BaseIntegrationTest {
     void getAllReservation() throws Exception {
         Owner owner = ownerRepository.findAll().get(0);
 
-        List<Reservation> reservations = reservationRepository.findAllWithReservationTimeAndShopByShopId(owner.getShop().getId());
+        List<Reservation> reservations = reservationRepository.findAllWithReservationTimeAndShopByShopId(
+            owner.getShop().getId());
         Reservation reservation1 = reservations.get(0);
         Reservation reservation2 = reservations.get(1);
-
-
 
         mockMvc.perform(get("/owners/shop")
                 .contentType(APPLICATION_JSON)


### PR DESCRIPTION
close #76 
### ⛏ 작업 상세 내용

- 회원의 예약 조회 api 빠져있어서 추가
- 추가한 api에 대해 컨트롤러 통합테스트

### 📝 작업 요약

- 회원 예약 조회 api 구현

### **☑️** 중점적으로 리뷰 할 부분

- 아직 회원을 어디서 받아올 지 몰라 쿼리가 특정 회원의 예약을 다 가져오는게 아니라 그냥 존재하는 예약을 다 가져오는데 추후 수정 예정입니다.
