### PR TITLE
feat : JWT에 권한을 함께 넣어준다.

### DIFF
--- a/src/main/java/com/prgrms/catchtable/common/Role.java
+++ b/src/main/java/com/prgrms/catchtable/common/Role.java
@@ -1,5 +1,9 @@
 package com.prgrms.catchtable.common;
 
+import static com.prgrms.catchtable.common.exception.ErrorCode.INVALID_INPUT_TYPE;
+
+import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
+import java.util.Arrays;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -11,4 +15,15 @@ public enum Role {
     OWNER("ROLE_OWNER");
 
     private final String role;
+
+    public static Role of(String type){
+        return Arrays.stream(values())
+            .filter(role -> role.isEqual(type))
+            .findAny()
+            .orElseThrow(() -> new BadRequestCustomException(INVALID_INPUT_TYPE));
+    }
+
+    private boolean isEqual(String input) {
+        return input.equals(this.role);
+    }
 }

--- a/src/main/java/com/prgrms/catchtable/common/Role.java
+++ b/src/main/java/com/prgrms/catchtable/common/Role.java
@@ -16,7 +16,7 @@ public enum Role {
 
     private final String role;
 
-    public static Role of(String type){
+    public static Role of(String type) {
         return Arrays.stream(values())
             .filter(role -> role.isEqual(type))
             .findAny()

--- a/src/main/java/com/prgrms/catchtable/common/exception/ErrorCode.java
+++ b/src/main/java/com/prgrms/catchtable/common/exception/ErrorCode.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ErrorCode {
     NOT_EXIST_MEMBER("존재하지 않는 회원입니다."),
+    NOT_EXIST_OWNER("존재하지 않는 점주입니다."),
     NOT_FOUND_REFRESH_TOKEN("유효하지 않은 RefreshToken입니다."),
     TOKEN_EXPIRES("토큰이 만료되었습니다. 다시 로그인 해 주세요."),
 

--- a/src/main/java/com/prgrms/catchtable/common/exception/ErrorCode.java
+++ b/src/main/java/com/prgrms/catchtable/common/exception/ErrorCode.java
@@ -32,8 +32,8 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR("내부 서버 오류입니다."),
 
     ALREADY_EXIST_OWNER("이미 존재하는 점주입니다"),
-    BAD_REQUEST_EMAIL_OR_PASSWORD("이메일 혹은 비밀번호를 확인해주세요"),
-    BAD_REQUEST_INPUT_GENDER_TYPE("성별 타입을 양식대로 입력해주세요");
+    INVALID_EMAIL_OR_PASSWORD("이메일 혹은 비밀번호를 확인해주세요"),
+    INVALID_INPUT_TYPE("잘못된 타입입니다.");
 
     private final String message;
 }

--- a/src/main/java/com/prgrms/catchtable/common/exception/ErrorCode.java
+++ b/src/main/java/com/prgrms/catchtable/common/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     NOT_EXIST_RESERVATION("존재하지 않는 예약입니다"),
     EXCEED_PEOPLE_COUNT("예약인원이 해당 시간의 남은 수용가능 인원 수를 초과했습니다."),
     ALREADY_COMPLETED_RESERVATION("이미 예약 상태인 예약입니다."),
+    SLACK_ID_IS_WRONG("요청한 슬랙 Id를 찾을 수 없거나 잘못 되었습니다"),
 
     CAN_NOT_COMPLETE_WAITING("입장 처리가 불가한 대기 상태입니다."),
     EXISTING_MEMBER_WAITING("이미 회원이 웨이팅 중인 가게가 존재합니다."),
@@ -33,7 +34,7 @@ public enum ErrorCode {
 
     ALREADY_EXIST_OWNER("이미 존재하는 점주입니다"),
     INVALID_EMAIL_OR_PASSWORD("이메일 혹은 비밀번호를 확인해주세요"),
-    INVALID_INPUT_TYPE("잘못된 타입입니다.");
+    INVALID_INPUT_TYPE("성별 타입을 양식대로 입력해주세요");
 
     private final String message;
 }

--- a/src/main/java/com/prgrms/catchtable/jwt/domain/RefreshToken.java
+++ b/src/main/java/com/prgrms/catchtable/jwt/domain/RefreshToken.java
@@ -1,6 +1,6 @@
 package com.prgrms.catchtable.jwt.domain;
 
-import static jakarta.persistence.EnumType.*;
+import static jakarta.persistence.EnumType.STRING;
 import static lombok.AccessLevel.PROTECTED;
 
 import com.prgrms.catchtable.common.Role;

--- a/src/main/java/com/prgrms/catchtable/jwt/domain/RefreshToken.java
+++ b/src/main/java/com/prgrms/catchtable/jwt/domain/RefreshToken.java
@@ -1,9 +1,12 @@
 package com.prgrms.catchtable.jwt.domain;
 
+import static jakarta.persistence.EnumType.*;
 import static lombok.AccessLevel.PROTECTED;
 
+import com.prgrms.catchtable.common.Role;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -26,10 +29,15 @@ public class RefreshToken {
     @Column(name = "email")
     private String email;
 
+    @Column(name = "role")
+    @Enumerated(STRING)
+    private Role role;
+
     @Builder
-    public RefreshToken(String token, String email) {
+    public RefreshToken(String token, String email, Role role) {
         this.token = token;
         this.email = email;
+        this.role = role;
     }
 
 }

--- a/src/main/java/com/prgrms/catchtable/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/prgrms/catchtable/jwt/filter/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package com.prgrms.catchtable.jwt.filter;
 
 import static com.prgrms.catchtable.common.exception.ErrorCode.TOKEN_EXPIRES;
 
+import com.prgrms.catchtable.common.Role;
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import com.prgrms.catchtable.jwt.domain.RefreshToken;
 import com.prgrms.catchtable.jwt.provider.JwtTokenProvider;
@@ -48,7 +49,8 @@ public class JwtAuthenticationFilter extends GenericFilter {
                         RefreshToken refreshTokenEntity = refreshTokenService.getRefreshTokenByToken(
                             refreshToken);
                         String email = refreshTokenEntity.getEmail();
-                        Token newToken = jwtTokenProvider.createToken(email);
+                        Role role = refreshTokenEntity.getRole();
+                        Token newToken = jwtTokenProvider.createToken(email, role);
 
                         ((HttpServletResponse) response).setHeader("AccessToken",
                             newToken.getAccessToken());

--- a/src/main/java/com/prgrms/catchtable/jwt/provider/JwtTokenProvider.java
+++ b/src/main/java/com/prgrms/catchtable/jwt/provider/JwtTokenProvider.java
@@ -75,7 +75,9 @@ public class JwtTokenProvider {
 
     public Authentication getAuthentication(String token) {
         String email = getEmail(token);
-        UserDetails userDetails = jwtUserDetailsService.loadUserByUsername(email);
+        Role role = getRole(token);
+
+        UserDetails userDetails = jwtUserDetailsService.loadUserByUsername(email, role);
         return new UsernamePasswordAuthenticationToken(userDetails, "",
             userDetails.getAuthorities());
     }
@@ -88,5 +90,15 @@ public class JwtTokenProvider {
             .getBody();
 
         return claims.getSubject();
+    }
+
+    private Role getRole(String token){
+        Claims claims = Jwts.parserBuilder()
+            .setSigningKey(jwtConfig.getClientSecret())
+            .build()
+            .parseClaimsJws(token)
+            .getBody();
+
+        return (Role) claims.get(JWT_ROLE);
     }
 }

--- a/src/main/java/com/prgrms/catchtable/jwt/provider/JwtTokenProvider.java
+++ b/src/main/java/com/prgrms/catchtable/jwt/provider/JwtTokenProvider.java
@@ -27,7 +27,7 @@ public class JwtTokenProvider {
     public Token createToken(String email, Role role) {
 
         Claims claims = Jwts.claims().setSubject(email);
-        claims.put(JWT_ROLE, role);
+        claims.put(JWT_ROLE, role.getRole());
         Date now = new Date();
 
         String accessToken = createAccessToken(claims, now);
@@ -99,6 +99,8 @@ public class JwtTokenProvider {
             .parseClaimsJws(token)
             .getBody();
 
-        return (Role) claims.get(JWT_ROLE);
+        String role = (String) claims.get(JWT_ROLE);
+
+        return Role.of(role);
     }
 }

--- a/src/main/java/com/prgrms/catchtable/jwt/provider/JwtTokenProvider.java
+++ b/src/main/java/com/prgrms/catchtable/jwt/provider/JwtTokenProvider.java
@@ -22,7 +22,7 @@ public class JwtTokenProvider {
 
     private final JwtConfig jwtConfig;
     private final JwtUserDetailsService jwtUserDetailsService;
-    private final String JWT_ROLE= "ROLE";
+    private final String JWT_ROLE = "ROLE";
 
     public Token createToken(String email, Role role) {
 
@@ -92,7 +92,7 @@ public class JwtTokenProvider {
         return claims.getSubject();
     }
 
-    private Role getRole(String token){
+    private Role getRole(String token) {
         Claims claims = Jwts.parserBuilder()
             .setSigningKey(jwtConfig.getClientSecret())
             .build()

--- a/src/main/java/com/prgrms/catchtable/jwt/provider/JwtTokenProvider.java
+++ b/src/main/java/com/prgrms/catchtable/jwt/provider/JwtTokenProvider.java
@@ -1,6 +1,7 @@
 package com.prgrms.catchtable.jwt.provider;
 
 
+import com.prgrms.catchtable.common.Role;
 import com.prgrms.catchtable.jwt.config.JwtConfig;
 import com.prgrms.catchtable.jwt.service.JwtUserDetailsService;
 import com.prgrms.catchtable.jwt.token.Token;
@@ -20,18 +21,19 @@ import org.springframework.stereotype.Component;
 public class JwtTokenProvider {
 
     private final JwtConfig jwtConfig;
-
     private final JwtUserDetailsService jwtUserDetailsService;
+    private final String JWT_ROLE= "ROLE";
 
-    public Token createToken(String email) {
+    public Token createToken(String email, Role role) {
 
         Claims claims = Jwts.claims().setSubject(email);
+        claims.put(JWT_ROLE, role);
         Date now = new Date();
 
         String accessToken = createAccessToken(claims, now);
         String refreshToken = createRefreshToken(claims, now);
 
-        return new Token(accessToken, refreshToken, email);
+        return new Token(accessToken, refreshToken, email, role);
     }
 
     private String createAccessToken(Claims claims, Date now) {

--- a/src/main/java/com/prgrms/catchtable/jwt/service/JwtUserDetailsService.java
+++ b/src/main/java/com/prgrms/catchtable/jwt/service/JwtUserDetailsService.java
@@ -14,19 +14,18 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class JwtUserDetailsService{
+public class JwtUserDetailsService {
 
     private final MemberRepository memberRepository;
     private final OwnerRepository ownerRepository;
 
-    public UserDetails loadUserByUsername(String email, Role role) throws UsernameNotFoundException {
+    public UserDetails loadUserByUsername(String email, Role role)
+        throws UsernameNotFoundException {
 
-        if(role.equals(Role.MEMBER)){
+        if (role.equals(Role.MEMBER)) {
             return memberRepository.findMemberByEmail(email)
                 .orElseThrow(() -> new NotFoundCustomException(NOT_EXIST_MEMBER));
-        }
-
-        else{
+        } else {
             return ownerRepository.findOwnerByEmail(email)
                 .orElseThrow(() -> new NotFoundCustomException(NOT_EXIST_OWNER));
         }

--- a/src/main/java/com/prgrms/catchtable/jwt/service/JwtUserDetailsService.java
+++ b/src/main/java/com/prgrms/catchtable/jwt/service/JwtUserDetailsService.java
@@ -1,24 +1,34 @@
 package com.prgrms.catchtable.jwt.service;
 
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_MEMBER;
+import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_OWNER;
 
+import com.prgrms.catchtable.common.Role;
 import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
 import com.prgrms.catchtable.member.repository.MemberRepository;
+import com.prgrms.catchtable.owner.repository.OwnerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class JwtUserDetailsService implements UserDetailsService {
+public class JwtUserDetailsService{
 
     private final MemberRepository memberRepository;
+    private final OwnerRepository ownerRepository;
 
-    @Override
-    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        return memberRepository.findMemberByEmail(email)
-            .orElseThrow(() -> new NotFoundCustomException(NOT_EXIST_MEMBER));
+    public UserDetails loadUserByUsername(String email, Role role) throws UsernameNotFoundException {
+
+        if(role.equals(Role.MEMBER)){
+            return memberRepository.findMemberByEmail(email)
+                .orElseThrow(() -> new NotFoundCustomException(NOT_EXIST_MEMBER));
+        }
+
+        else{
+            return ownerRepository.findOwnerByEmail(email)
+                .orElseThrow(() -> new NotFoundCustomException(NOT_EXIST_OWNER));
+        }
     }
 }

--- a/src/main/java/com/prgrms/catchtable/jwt/service/RefreshTokenService.java
+++ b/src/main/java/com/prgrms/catchtable/jwt/service/RefreshTokenService.java
@@ -2,6 +2,7 @@ package com.prgrms.catchtable.jwt.service;
 
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_FOUND_REFRESH_TOKEN;
 
+import com.prgrms.catchtable.common.Role;
 import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
 import com.prgrms.catchtable.jwt.domain.RefreshToken;
 import com.prgrms.catchtable.jwt.repository.RefreshTokenRepository;
@@ -19,6 +20,7 @@ public class RefreshTokenService {
     @Transactional
     public void saveRefreshToken(Token totalToken) {
         String email = totalToken.getEmail();
+        Role role = totalToken.getRole();
 
         if (refreshTokenRepository.existsRefreshTokenByEmail(email)) {
             refreshTokenRepository.deleteRefreshTokenByEmail(email);
@@ -27,6 +29,7 @@ public class RefreshTokenService {
         RefreshToken newRefreshToken = RefreshToken.builder()
             .token(totalToken.getRefreshToken())
             .email(email)
+            .role(role)
             .build();
 
         refreshTokenRepository.save(newRefreshToken);

--- a/src/main/java/com/prgrms/catchtable/jwt/token/Token.java
+++ b/src/main/java/com/prgrms/catchtable/jwt/token/Token.java
@@ -1,5 +1,6 @@
 package com.prgrms.catchtable.jwt.token;
 
+import com.prgrms.catchtable.common.Role;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -12,4 +13,6 @@ public class Token {
     private String refreshToken;
 
     private String email;
+
+    private Role role;
 }

--- a/src/main/java/com/prgrms/catchtable/member/domain/Gender.java
+++ b/src/main/java/com/prgrms/catchtable/member/domain/Gender.java
@@ -1,6 +1,6 @@
 package com.prgrms.catchtable.member.domain;
 
-import static com.prgrms.catchtable.common.exception.ErrorCode.BAD_REQUEST_INPUT_GENDER_TYPE;
+import static com.prgrms.catchtable.common.exception.ErrorCode.INVALID_INPUT_TYPE;
 
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import java.util.Arrays;
@@ -19,7 +19,7 @@ public enum Gender {
         return Arrays.stream(values())
             .filter(gender -> gender.isEqual(input))
             .findAny()
-            .orElseThrow(() -> new BadRequestCustomException(BAD_REQUEST_INPUT_GENDER_TYPE));
+            .orElseThrow(() -> new BadRequestCustomException(INVALID_INPUT_TYPE));
     }
 
     private boolean isEqual(String input) {

--- a/src/main/java/com/prgrms/catchtable/member/service/MemberService.java
+++ b/src/main/java/com/prgrms/catchtable/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.prgrms.catchtable.member.service;
 
+import com.prgrms.catchtable.common.Role;
 import com.prgrms.catchtable.jwt.provider.JwtTokenProvider;
 import com.prgrms.catchtable.jwt.service.RefreshTokenService;
 import com.prgrms.catchtable.jwt.token.Token;
@@ -34,7 +35,7 @@ public class MemberService {
     }
 
     private Token createTotalToken(String email) {
-        Token totalToken = jwtTokenProvider.createToken(email);
+        Token totalToken = jwtTokenProvider.createToken(email, Role.MEMBER);
         refreshTokenService.saveRefreshToken(totalToken);
         return totalToken;
     }

--- a/src/main/java/com/prgrms/catchtable/member/service/MemberService.java
+++ b/src/main/java/com/prgrms/catchtable/member/service/MemberService.java
@@ -17,10 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
-
-    private final JwtTokenProvider jwtTokenProvider;
-
     private final RefreshTokenService refreshTokenService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
     public Token oauthLogin(OAuthAttribute attributes) {

--- a/src/main/java/com/prgrms/catchtable/owner/service/OwnerService.java
+++ b/src/main/java/com/prgrms/catchtable/owner/service/OwnerService.java
@@ -5,6 +5,7 @@ import static com.prgrms.catchtable.common.exception.ErrorCode.BAD_REQUEST_EMAIL
 
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import com.prgrms.catchtable.jwt.provider.JwtTokenProvider;
+import com.prgrms.catchtable.jwt.service.RefreshTokenService;
 import com.prgrms.catchtable.jwt.token.Token;
 import com.prgrms.catchtable.member.domain.Gender;
 import com.prgrms.catchtable.owner.domain.Owner;
@@ -25,6 +26,7 @@ public class OwnerService {
     private final OwnerRepository ownerRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
 
     @Transactional
     public JoinOwnerResponse joinOwner(JoinOwnerRequest joinOwnerRequest) {
@@ -59,13 +61,19 @@ public class OwnerService {
         //password 확인
         validatePassword(loginRequest, loginOwner);
 
-        return jwtTokenProvider.createToken(loginOwner.getEmail());
+        return createTotalToken(loginOwner.getEmail());
     }
 
     private void validatePassword(LoginOwnerRequest loginRequest, Owner loginOwner) {
         if (!passwordEncoder.matches(loginRequest.password(), loginOwner.getPassword())) {
             throw new BadRequestCustomException(BAD_REQUEST_EMAIL_OR_PASSWORD);
         }
+    }
+
+    private Token createTotalToken(String email){
+        Token totalToken = jwtTokenProvider.createToken(email);
+        refreshTokenService.saveRefreshToken(totalToken);
+        return totalToken;
     }
 
 }

--- a/src/main/java/com/prgrms/catchtable/owner/service/OwnerService.java
+++ b/src/main/java/com/prgrms/catchtable/owner/service/OwnerService.java
@@ -3,6 +3,7 @@ package com.prgrms.catchtable.owner.service;
 import static com.prgrms.catchtable.common.exception.ErrorCode.ALREADY_EXIST_OWNER;
 import static com.prgrms.catchtable.common.exception.ErrorCode.BAD_REQUEST_EMAIL_OR_PASSWORD;
 
+import com.prgrms.catchtable.common.Role;
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import com.prgrms.catchtable.jwt.provider.JwtTokenProvider;
 import com.prgrms.catchtable.jwt.service.RefreshTokenService;
@@ -71,7 +72,7 @@ public class OwnerService {
     }
 
     private Token createTotalToken(String email){
-        Token totalToken = jwtTokenProvider.createToken(email);
+        Token totalToken = jwtTokenProvider.createToken(email, Role.OWNER);
         refreshTokenService.saveRefreshToken(totalToken);
         return totalToken;
     }

--- a/src/main/java/com/prgrms/catchtable/owner/service/OwnerService.java
+++ b/src/main/java/com/prgrms/catchtable/owner/service/OwnerService.java
@@ -1,7 +1,6 @@
 package com.prgrms.catchtable.owner.service;
 
-import static com.prgrms.catchtable.common.exception.ErrorCode.ALREADY_EXIST_OWNER;
-import static com.prgrms.catchtable.common.exception.ErrorCode.BAD_REQUEST_EMAIL_OR_PASSWORD;
+import static com.prgrms.catchtable.common.exception.ErrorCode.*;
 
 import com.prgrms.catchtable.common.Role;
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
@@ -57,7 +56,7 @@ public class OwnerService {
 
         //email 확인
         Owner loginOwner = ownerRepository.findOwnerByEmail(loginRequest.email())
-            .orElseThrow(() -> new BadRequestCustomException(BAD_REQUEST_EMAIL_OR_PASSWORD));
+            .orElseThrow(() -> new BadRequestCustomException(INVALID_EMAIL_OR_PASSWORD));
 
         //password 확인
         validatePassword(loginRequest, loginOwner);
@@ -67,7 +66,7 @@ public class OwnerService {
 
     private void validatePassword(LoginOwnerRequest loginRequest, Owner loginOwner) {
         if (!passwordEncoder.matches(loginRequest.password(), loginOwner.getPassword())) {
-            throw new BadRequestCustomException(BAD_REQUEST_EMAIL_OR_PASSWORD);
+            throw new BadRequestCustomException(INVALID_EMAIL_OR_PASSWORD);
         }
     }
 

--- a/src/main/java/com/prgrms/catchtable/owner/service/OwnerService.java
+++ b/src/main/java/com/prgrms/catchtable/owner/service/OwnerService.java
@@ -16,6 +16,7 @@ import com.prgrms.catchtable.owner.repository.OwnerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +26,7 @@ public class OwnerService {
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
 
+    @Transactional
     public JoinOwnerResponse joinOwner(JoinOwnerRequest joinOwnerRequest) {
 
         //이미 존재하는 이메일이라면
@@ -47,6 +49,7 @@ public class OwnerService {
         }
     }
 
+    @Transactional
     public Token loginOwner(LoginOwnerRequest loginRequest) {
 
         //email 확인

--- a/src/main/java/com/prgrms/catchtable/owner/service/OwnerService.java
+++ b/src/main/java/com/prgrms/catchtable/owner/service/OwnerService.java
@@ -1,6 +1,7 @@
 package com.prgrms.catchtable.owner.service;
 
-import static com.prgrms.catchtable.common.exception.ErrorCode.*;
+import static com.prgrms.catchtable.common.exception.ErrorCode.ALREADY_EXIST_OWNER;
+import static com.prgrms.catchtable.common.exception.ErrorCode.INVALID_EMAIL_OR_PASSWORD;
 
 import com.prgrms.catchtable.common.Role;
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
@@ -70,7 +71,7 @@ public class OwnerService {
         }
     }
 
-    private Token createTotalToken(String email){
+    private Token createTotalToken(String email) {
         Token totalToken = jwtTokenProvider.createToken(email, Role.OWNER);
         refreshTokenService.saveRefreshToken(totalToken);
         return totalToken;

--- a/src/main/java/com/prgrms/catchtable/reservation/service/OwnerReservationService.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/service/OwnerReservationService.java
@@ -40,7 +40,7 @@ public class OwnerReservationService {
     ) {
         ReservationStatus modifyStatus = request.status(); // 요청으로 들어온 변경하려는 예약상태 추출
 
-        if(modifyStatus == COMPLETED){ // 취소, 노쇼 처리가 아닌 경우 예외
+        if (modifyStatus == COMPLETED) { // 취소, 노쇼 처리가 아닌 경우 예외
             throw new BadRequestCustomException(ALREADY_COMPLETED_RESERVATION);
         }
 

--- a/src/test/java/com/prgrms/catchtable/jwt/provider/JwtTokenProviderTest.java
+++ b/src/test/java/com/prgrms/catchtable/jwt/provider/JwtTokenProviderTest.java
@@ -3,6 +3,7 @@ package com.prgrms.catchtable.jwt.provider;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import com.prgrms.catchtable.common.Role;
 import com.prgrms.catchtable.jwt.config.JwtConfig;
 import com.prgrms.catchtable.jwt.service.JwtUserDetailsService;
 import com.prgrms.catchtable.jwt.token.Token;
@@ -34,7 +35,7 @@ class JwtTokenProviderTest {
         when(config.getClientSecret()).thenReturn(clientKey);
         when(config.getExpiryMinute()).thenReturn(1);
         when(config.getExpiryMinuteRefresh()).thenReturn(1);
-        Token token = jwtTokenProvider.createToken(email);
+        Token token = jwtTokenProvider.createToken(email, Role.MEMBER);
 
         //then
         assertThat(jwtTokenProvider.validateToken(token.getAccessToken())).isTrue();
@@ -48,7 +49,7 @@ class JwtTokenProviderTest {
         when(config.getClientSecret()).thenReturn(clientKey);
         when(config.getExpiryMinute()).thenReturn(0);
         when(config.getExpiryMinuteRefresh()).thenReturn(0);
-        Token token = jwtTokenProvider.createToken(email);
+        Token token = jwtTokenProvider.createToken(email, Role.OWNER);
 
         //then
         assertThat(jwtTokenProvider.validateToken(token.getAccessToken())).isFalse();
@@ -65,9 +66,9 @@ class JwtTokenProviderTest {
         when(config.getClientSecret()).thenReturn(clientKey);
         when(config.getExpiryMinute()).thenReturn(1);
         when(config.getExpiryMinuteRefresh()).thenReturn(1);
-        Token token = jwtTokenProvider.createToken(email);
+        Token token = jwtTokenProvider.createToken(email, Role.MEMBER);
 
-        when(jwtUserDetailsService.loadUserByUsername(email))
+        when(jwtUserDetailsService.loadUserByUsername(email, Role.MEMBER))
             .thenReturn(member);
 
         //then

--- a/src/test/java/com/prgrms/catchtable/jwt/service/JwtUserDetailsServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/jwt/service/JwtUserDetailsServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
+import com.prgrms.catchtable.common.Role;
 import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
 import com.prgrms.catchtable.member.MemberFixture;
 import com.prgrms.catchtable.member.domain.Member;
@@ -37,9 +38,9 @@ class JwtUserDetailsServiceTest {
         when(memberRepository.findMemberByEmail(invalidEmail)).thenReturn(Optional.empty());
 
         //then
-        assertThat(jwtUserDetailsService.loadUserByUsername(email)).isEqualTo(member);
+        assertThat(jwtUserDetailsService.loadUserByUsername(email, Role.MEMBER)).isEqualTo(member);
         assertThatThrownBy(
-            () -> jwtUserDetailsService.loadUserByUsername(invalidEmail)).isInstanceOf(
+            () -> jwtUserDetailsService.loadUserByUsername(invalidEmail, Role.MEMBER)).isInstanceOf(
             NotFoundCustomException.class);
 
     }

--- a/src/test/java/com/prgrms/catchtable/jwt/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/jwt/service/RefreshTokenServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.prgrms.catchtable.common.Role;
 import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
 import com.prgrms.catchtable.jwt.config.JwtConfig;
 import com.prgrms.catchtable.jwt.domain.RefreshToken;
@@ -45,7 +46,7 @@ class RefreshTokenServiceTest {
         when(jwtConfig.getClientSecret()).thenReturn(clientSecretKey);
         when(jwtConfig.getExpiryMinute()).thenReturn(1);
         when(jwtConfig.getExpiryMinuteRefresh()).thenReturn(1);
-        token = jwtTokenProvider.createToken(email);
+        token = jwtTokenProvider.createToken(email, Role.OWNER);
     }
 
     @Test
@@ -65,7 +66,7 @@ class RefreshTokenServiceTest {
     @DisplayName("이미 유효한 RefreshToken을 갖고 있는 유저가 RefreshToken을 새로 발급한다면, DB에서 삭제 후 저장해준다.")
     void deleteAndSaveRefreshToken() {
         //given
-        Token newToken = jwtTokenProvider.createToken(email);
+        Token newToken = jwtTokenProvider.createToken(email, Role.OWNER);
 
         //when
         when(refreshTokenRepository.existsRefreshTokenByEmail(email)).thenReturn(true);
@@ -83,7 +84,7 @@ class RefreshTokenServiceTest {
     void getRefreshTokenTest() {
         //given
         String invalidEmail = "qwer1234@naver.com";
-        Token invalidToken = jwtTokenProvider.createToken(invalidEmail);
+        Token invalidToken = jwtTokenProvider.createToken(invalidEmail, Role.OWNER);
 
         RefreshToken refreshToken = RefreshToken.builder()
             .token(token.getRefreshToken())

--- a/src/test/java/com/prgrms/catchtable/owner/controller/OwnerControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/owner/controller/OwnerControllerTest.java
@@ -5,6 +5,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.prgrms.catchtable.common.Role;
 import com.prgrms.catchtable.common.base.BaseIntegrationTest;
 import com.prgrms.catchtable.jwt.provider.JwtTokenProvider;
 import com.prgrms.catchtable.jwt.token.Token;
@@ -73,7 +74,7 @@ class OwnerControllerTest extends BaseIntegrationTest {
         //given
         LoginOwnerRequest loginOwnerRequest = OwnerFixture.getLoginOwnerRequest(joinEmail,
             password);
-        Token token = jwtTokenProvider.createToken(joinEmail);
+        Token token = jwtTokenProvider.createToken(joinEmail, Role.OWNER);
 
         //then
         mockMvc.perform(post("/owners/login")

--- a/src/test/java/com/prgrms/catchtable/owner/service/OwnerServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/owner/service/OwnerServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import com.prgrms.catchtable.jwt.provider.JwtTokenProvider;
+import com.prgrms.catchtable.jwt.service.RefreshTokenService;
 import com.prgrms.catchtable.jwt.token.Token;
 import com.prgrms.catchtable.owner.domain.Owner;
 import com.prgrms.catchtable.owner.dto.request.JoinOwnerRequest;
@@ -24,10 +25,11 @@ class OwnerServiceTest {
 
     private final OwnerRepository ownerRepository = mock(OwnerRepository.class);
     private final JwtTokenProvider jwtTokenProvider = mock(JwtTokenProvider.class);
+    private final RefreshTokenService refreshTokenService = mock(RefreshTokenService.class);
     private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
     private final OwnerService ownerService = new OwnerService(ownerRepository, passwordEncoder,
-        jwtTokenProvider);
+        jwtTokenProvider, refreshTokenService);
 
     private final String email = "abc1234@gmail.com";
     private final String password = "qwer1234";

--- a/src/test/java/com/prgrms/catchtable/owner/service/OwnerServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/owner/service/OwnerServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.prgrms.catchtable.common.Role;
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import com.prgrms.catchtable.jwt.provider.JwtTokenProvider;
 import com.prgrms.catchtable.jwt.service.RefreshTokenService;
@@ -77,12 +78,12 @@ class OwnerServiceTest {
         //given
         LoginOwnerRequest loginOwnerRequest = OwnerFixture.getLoginOwnerRequest(email, password);
         String encodePassword = passwordEncoder.encode(password);
-        Token token = new Token("AccessToken", "RefreshToken", loginOwnerRequest.email());
+        Token token = new Token("AccessToken", "RefreshToken", loginOwnerRequest.email(), Role.OWNER);
 
         //when
         when(ownerRepository.findOwnerByEmail(loginOwnerRequest.email())).thenReturn(
             Optional.of(OwnerFixture.getOwner(email, encodePassword)));
-        when(jwtTokenProvider.createToken(loginOwnerRequest.email())).thenReturn(token);
+        when(jwtTokenProvider.createToken(loginOwnerRequest.email(), Role.OWNER)).thenReturn(token);
 
         //then
         assertThat(ownerService.loginOwner(loginOwnerRequest)).isEqualTo(token);

--- a/src/test/java/com/prgrms/catchtable/security/controller/JwtAuthenticationTest.java
+++ b/src/test/java/com/prgrms/catchtable/security/controller/JwtAuthenticationTest.java
@@ -3,6 +3,7 @@ package com.prgrms.catchtable.security.controller;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.prgrms.catchtable.common.Role;
 import com.prgrms.catchtable.jwt.filter.JwtAuthenticationFilter;
 import com.prgrms.catchtable.jwt.provider.JwtTokenProvider;
 import com.prgrms.catchtable.jwt.service.RefreshTokenService;
@@ -55,7 +56,7 @@ class JwtAuthenticationTest {
         memberRepository.save(loginMember);
 
         //토큰 발급
-        token = jwtTokenProvider.createToken(email);
+        token = jwtTokenProvider.createToken(email, Role.MEMBER);
         refreshTokenService.saveRefreshToken(token);
 
         //필터 추가


### PR DESCRIPTION
### ⛏ 작업 상세 내용

- 로그인 후 발급되는 JWT에 권한을 함께 넣어준다.
- RefreshToken을 서버에 저장 시, 권한도 함께 저장해준다.
- 로그인 후 요청 시, 권한을 통해 Member인지 Owner인지 구분한다.

### 📝 작업 요약

- 

### **☑️** 중점적으로 리뷰 할 부분

- MemberService의 로그인 로직
- OwnerService의 로그인 로직
- JwtAuthenticationFilter의 요청 시 JWT 검증 로직
