### PR TITLE
feat : 현재 로그인 정보 조회 어노테이션 추가 (@LogIn)

### DIFF
--- a/src/main/java/com/prgrms/catchtable/common/login/LogIn.java
+++ b/src/main/java/com/prgrms/catchtable/common/login/LogIn.java
@@ -1,0 +1,12 @@
+package com.prgrms.catchtable.common.login;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LogIn {
+
+}

--- a/src/main/java/com/prgrms/catchtable/common/login/LogInArgumentResolver.java
+++ b/src/main/java/com/prgrms/catchtable/common/login/LogInArgumentResolver.java
@@ -1,0 +1,32 @@
+package com.prgrms.catchtable.common.login;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class LogInArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasLoginAnnotation = parameter.hasParameterAnnotation(LogIn.class);
+        boolean hasUserDetails = UserDetails.class.isAssignableFrom(parameter.getParameterType());
+
+        return hasLoginAnnotation && hasUserDetails;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return authentication.getPrincipal();
+    }
+}

--- a/src/main/java/com/prgrms/catchtable/common/login/WebConfig.java
+++ b/src/main/java/com/prgrms/catchtable/common/login/WebConfig.java
@@ -1,0 +1,16 @@
+package com.prgrms.catchtable.common.login;
+
+import java.util.List;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers){
+        resolvers.add(new LogInArgumentResolver());
+    }
+
+}


### PR DESCRIPTION
### ⛏ 작업 상세 내용

- 예약, 웨이팅과 같은 기능들은 인증과 인가된 사용자만 이용할 수 있는 기능입니다!
- 로그인 후 SecurityContext에서 인증과 인가가 완료된 유저들의 정보를 컨트롤러에서 쉽게 가져오도록 하였습니다!

### 📝 작업 요약

- 현재 Member나 Owner의 정보를 RequestParam이나 Pathvariable로 갖고오는 것보다는 해당 기능을 사용하는 것이 좀 더 바람직 할 것 같습니다~!

- 수정 전
```
@PatchMapping("/{memberId}")
    public ResponseEntity<WaitingResponse> postponeWaiting(
        @PathVariable("memberId") Long memberId) {
        .
        .
    }
```

- 수정 후
```
@PatchMapping
    public ResponseEntity<WaitingResponse> postponeWaiting(
        @LogIn Member member) {
        .
        .
    }
```

### **☑️** 중점적으로 리뷰 할 부분

- 해당 기능이 로그인을 완료 후, 요청 시 JWT 토큰을 헤더에 넘겨줄 때 완벽한 기능이라 지금 당장은 기능이 동작 안 할 수도 있습니다..!!