### PR TITLE
feat : 유저 웨이팅 입장 API 구현

### DIFF
--- a/src/main/java/com/prgrms/catchtable/common/exception/ErrorCode.java
+++ b/src/main/java/com/prgrms/catchtable/common/exception/ErrorCode.java
@@ -27,7 +27,8 @@ public enum ErrorCode {
     POSTPONE_REMAINING_CNT_0("이미 두 차례 대기를 미뤘습니다."),
     CAN_NOT_CANCEL_WAITING("웨이팅 취소 처리가 불가한 상태입니다."),
     CAN_NOT_ENTRY("웨이팅을 입장 처리할 수 없습니다"),
-    WAITING_DOES_NOT_EXIST("웨이팅이 존재하지 않습니다"),
+    WAITING_DOES_NOT_EXIST("해당 아이디의 웨이팅이 존재하지 않습니다."),
+    WAITING_LINE_EMPTY("가게에 웨이팅이 존재하지 않습니다."),
     SHOP_NOT_RUNNING("가게가 영업시간이 아닙니다."),
     INTERNAL_SERVER_ERROR("내부 서버 오류입니다."),
 

--- a/src/main/java/com/prgrms/catchtable/waiting/controller/OwnerWaitingController.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/controller/OwnerWaitingController.java
@@ -1,10 +1,12 @@
 package com.prgrms.catchtable.waiting.controller;
 
 import com.prgrms.catchtable.waiting.dto.response.OwnerWaitingListResponse;
+import com.prgrms.catchtable.waiting.dto.response.OwnerWaitingResponse;
 import com.prgrms.catchtable.waiting.service.OwnerWaitingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,6 +22,12 @@ public class OwnerWaitingController {
     public ResponseEntity<OwnerWaitingListResponse> getOwnerAllWaiting(
         @PathVariable("ownerId") Long ownerId) {
         OwnerWaitingListResponse response = ownerWaitingService.getOwnerAllWaiting(ownerId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/{ownerId}")
+    public ResponseEntity<OwnerWaitingResponse> entryWaiting(@PathVariable("ownerId") Long ownerId){
+        OwnerWaitingResponse response = ownerWaitingService.entryWaiting(ownerId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/prgrms/catchtable/waiting/controller/OwnerWaitingController.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/controller/OwnerWaitingController.java
@@ -26,7 +26,8 @@ public class OwnerWaitingController {
     }
 
     @PatchMapping("/{ownerId}")
-    public ResponseEntity<OwnerWaitingResponse> entryWaiting(@PathVariable("ownerId") Long ownerId){
+    public ResponseEntity<OwnerWaitingResponse> entryWaiting(
+        @PathVariable("ownerId") Long ownerId) {
         OwnerWaitingResponse response = ownerWaitingService.entryWaiting(ownerId);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepository.java
@@ -26,12 +26,9 @@ public class BasicWaitingLineRepository implements WaitingLineRepository {
         waitingLine.add(waitingId);
     }
 
-    public void entry(Long shopId, Long waitingId) {
+    public Long entry(Long shopId) {
         Queue<Long> waitingLine = waitingLines.get(shopId);
-        if (!Objects.equals(waitingLine.peek(), waitingId)) {
-            throw new BadRequestCustomException(CAN_NOT_ENTRY);
-        }
-        waitingLine.remove();
+        return waitingLine.remove();
     }
 
     public List<Long> getShopWaitingIdsInOrder(Long shopId) {

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepository.java
@@ -1,7 +1,6 @@
 package com.prgrms.catchtable.waiting.repository.waitingline;
 
 import static com.prgrms.catchtable.common.exception.ErrorCode.ALREADY_END_LINE;
-import static com.prgrms.catchtable.common.exception.ErrorCode.CAN_NOT_ENTRY;
 import static com.prgrms.catchtable.common.exception.ErrorCode.WAITING_DOES_NOT_EXIST;
 
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepository.java
@@ -2,6 +2,7 @@ package com.prgrms.catchtable.waiting.repository.waitingline;
 
 import static com.prgrms.catchtable.common.exception.ErrorCode.ALREADY_END_LINE;
 import static com.prgrms.catchtable.common.exception.ErrorCode.WAITING_DOES_NOT_EXIST;
+import static com.prgrms.catchtable.common.exception.ErrorCode.WAITING_LINE_EMPTY;
 
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
@@ -54,8 +55,8 @@ public class RedisWaitingLineRepository implements WaitingLineRepository {
             .toList());
     }
 
-    public void entry(Long shopId, Long waitingId) {
-        validateIfWaitingExists(shopId, waitingId);
+    public Long entry(Long shopId) {
+        Long waitingId = getShopWaitingIdsInOrder(shopId).get(0);
         redisTemplate.execute(new SessionCallback<>() {
             @Override
             public <K, V> Object execute(RedisOperations<K, V> operations)
@@ -70,8 +71,8 @@ public class RedisWaitingLineRepository implements WaitingLineRepository {
                 return operations.exec();
             }
         });
+        return waitingId;
     }
-
     public void cancel(Long shopId, Long waitingId) {
         validateIfWaitingExists(shopId, waitingId);
         redisTemplate.execute(new SessionCallback<>() {

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepository.java
@@ -2,7 +2,6 @@ package com.prgrms.catchtable.waiting.repository.waitingline;
 
 import static com.prgrms.catchtable.common.exception.ErrorCode.ALREADY_END_LINE;
 import static com.prgrms.catchtable.common.exception.ErrorCode.WAITING_DOES_NOT_EXIST;
-import static com.prgrms.catchtable.common.exception.ErrorCode.WAITING_LINE_EMPTY;
 
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
@@ -73,6 +72,7 @@ public class RedisWaitingLineRepository implements WaitingLineRepository {
         });
         return waitingId;
     }
+
     public void cancel(Long shopId, Long waitingId) {
         validateIfWaitingExists(shopId, waitingId);
         redisTemplate.execute(new SessionCallback<>() {

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/WaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/WaitingLineRepository.java
@@ -6,7 +6,7 @@ public interface WaitingLineRepository {
 
     void save(Long shopId, Long waitingId);
 
-    void entry(Long shopId, Long waitingId);
+    Long entry(Long shopId);
 
     void cancel(Long shopId, Long waitingId);
 

--- a/src/main/java/com/prgrms/catchtable/waiting/service/OwnerWaitingService.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/service/OwnerWaitingService.java
@@ -1,13 +1,17 @@
 package com.prgrms.catchtable.waiting.service;
 
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_OWNER;
+import static com.prgrms.catchtable.common.exception.ErrorCode.WAITING_DOES_NOT_EXIST;
 import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toOwnerWaitingListResponse;
+import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toOwnerWaitingResponse;
 
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
+import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
 import com.prgrms.catchtable.owner.domain.Owner;
 import com.prgrms.catchtable.owner.repository.OwnerRepository;
 import com.prgrms.catchtable.waiting.domain.Waiting;
 import com.prgrms.catchtable.waiting.dto.response.OwnerWaitingListResponse;
+import com.prgrms.catchtable.waiting.dto.response.OwnerWaitingResponse;
 import com.prgrms.catchtable.waiting.repository.WaitingRepository;
 import com.prgrms.catchtable.waiting.repository.waitingline.WaitingLineRepository;
 import java.util.List;
@@ -31,5 +35,16 @@ public class OwnerWaitingService {
             owner.getShop().getId());
         List<Waiting> waitings = waitingRepository.findByIds(waitingIds);
         return toOwnerWaitingListResponse(waitings);
+    }
+
+    @Transactional
+    public OwnerWaitingResponse entryWaiting(Long ownerId){
+        Owner owner = ownerRepository.findById(ownerId)
+            .orElseThrow(() -> new BadRequestCustomException(NOT_EXIST_OWNER));
+        Long enteredWaitingId = waitingLineRepository.entry(owner.getShop().getId());
+        Waiting waiting = waitingRepository.findById(enteredWaitingId)
+            .orElseThrow(() -> new NotFoundCustomException(WAITING_DOES_NOT_EXIST));
+        waiting.changeStatusCompleted();
+        return toOwnerWaitingResponse(waiting, 0L);
     }
 }

--- a/src/main/java/com/prgrms/catchtable/waiting/service/OwnerWaitingService.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/service/OwnerWaitingService.java
@@ -38,7 +38,7 @@ public class OwnerWaitingService {
     }
 
     @Transactional
-    public OwnerWaitingResponse entryWaiting(Long ownerId){
+    public OwnerWaitingResponse entryWaiting(Long ownerId) {
         Owner owner = ownerRepository.findById(ownerId)
             .orElseThrow(() -> new BadRequestCustomException(NOT_EXIST_OWNER));
         Long enteredWaitingId = waitingLineRepository.entry(owner.getShop().getId());

--- a/src/test/java/com/prgrms/catchtable/waiting/controller/OwnerWaitingControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/controller/OwnerWaitingControllerTest.java
@@ -1,6 +1,6 @@
 package com.prgrms.catchtable.waiting.controller;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -22,7 +22,6 @@ import com.prgrms.catchtable.waiting.domain.Waiting;
 import com.prgrms.catchtable.waiting.repository.WaitingRepository;
 import com.prgrms.catchtable.waiting.repository.waitingline.WaitingLineRepository;
 import java.util.List;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepositoryTest.java
@@ -30,9 +30,10 @@ class BasicWaitingLineRepositoryTest {
         repository.save(shopId, 3L);
 
         //when
-        repository.entry(1L, 1L);
+        Long enteredWaitingId = repository.entry(1L);
 
         //then
+        assertThat(enteredWaitingId).isEqualTo(1L);
         assertThat(repository.findRank(1L, 1L))
             .isEqualTo(-1);
         assertThat(repository.findRank(1L, 2L))

--- a/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepositoryTest.java
@@ -52,10 +52,9 @@ class RedisWaitingLineRepositoryTest {
         repository.save(shopId, 3L);
 
         //when
-        repository.entry(1L, 1L);
+        repository.entry(1L);
 
         //then
-
         assertThrows(NotFoundCustomException.class,
             () -> repository.findRank(1L, 1L));
         assertThat(repository.findRank(1L, 2L))
@@ -134,5 +133,16 @@ class RedisWaitingLineRepositoryTest {
         //then
         System.out.println("waitingIds = " + waitingIds);
         assertThat(waitingIds.get(0)).isEqualTo(1L);
+    }
+
+    @DisplayName("웨이팅이 없으면 웨이팅 사이즈 0을 반환한다.")
+    @Test
+    void getWaitingLineSize(){
+        //given
+        Long shopId = 1L;
+        //when
+        Long waitingLineSize = repository.getWaitingLineSize(shopId);
+        //then
+        assertThat(waitingLineSize).isZero();
     }
 }

--- a/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepositoryTest.java
@@ -137,7 +137,7 @@ class RedisWaitingLineRepositoryTest {
 
     @DisplayName("웨이팅이 없으면 웨이팅 사이즈 0을 반환한다.")
     @Test
-    void getWaitingLineSize(){
+    void getWaitingLineSize() {
         //given
         Long shopId = 1L;
         //when

--- a/src/test/java/com/prgrms/catchtable/waiting/service/OwnerWaitingServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/service/OwnerWaitingServiceTest.java
@@ -11,6 +11,7 @@ import com.prgrms.catchtable.owner.repository.OwnerRepository;
 import com.prgrms.catchtable.shop.domain.Shop;
 import com.prgrms.catchtable.waiting.domain.Waiting;
 import com.prgrms.catchtable.waiting.dto.response.OwnerWaitingListResponse;
+import com.prgrms.catchtable.waiting.dto.response.OwnerWaitingResponse;
 import com.prgrms.catchtable.waiting.fixture.WaitingFixture;
 import com.prgrms.catchtable.waiting.repository.WaitingRepository;
 import com.prgrms.catchtable.waiting.repository.waitingline.WaitingLineRepository;
@@ -70,5 +71,28 @@ class OwnerWaitingServiceTest {
         assertThat(response.shopWaitings().get(1).waitingId()).isEqualTo(waiting2.getId());
         assertThat(response.shopWaitings().get(1).waitingNumber()).isEqualTo(
             waiting2.getWaitingNumber());
+    }
+
+    @DisplayName("웨이팅 손님을 입장시킬 수 있다.")
+    @Test
+    void entryWaiting() {
+        //given
+        Member member = mock(Member.class);
+        Owner owner = mock(Owner.class);
+        Shop shop = mock(Shop.class);
+        Waiting waiting = WaitingFixture.waiting(member, shop, 1);
+
+        given(ownerRepository.findById(1L)).willReturn(Optional.of(owner));
+        given(owner.getShop()).willReturn(shop);
+        given(waitingLineRepository.entry(any(Long.class))).willReturn(1L);
+        given(waitingRepository.findById(1L)).willReturn(Optional.of(waiting));
+        //when
+        OwnerWaitingResponse response = ownerWaitingService.entryWaiting(1L);
+        //then
+        assertThat(response.waitingId()).isEqualTo(waiting.getId());
+        assertThat(response.peopleCount()).isEqualTo(2);
+        assertThat(response.rank()).isZero();
+        assertThat(response.waitingNumber()).isEqualTo(waiting.getWaitingNumber());
+
     }
 }


### PR DESCRIPTION
### ⛏ 작업 상세 내용

- redisWaitingLineRepository 입장 로직 수정
  - 입장하는 waitingId 반환
- 단위 테스트, 통합 테스트 작성
### 📝 작업 요약

- 유저 웨이팅 입장 API 설계 및 테스트 작성

### **☑️** 중점적으로 리뷰 할 부분

- redis queue entry(), 서비스 비즈니스 로직
