### PR TITLE
feat : 유저 모든 웨이팅 조회 API 구현

### DIFF
--- a/src/main/java/com/prgrms/catchtable/common/exception/ErrorCode.java
+++ b/src/main/java/com/prgrms/catchtable/common/exception/ErrorCode.java
@@ -27,7 +27,8 @@ public enum ErrorCode {
     POSTPONE_REMAINING_CNT_0("이미 두 차례 대기를 미뤘습니다."),
     CAN_NOT_CANCEL_WAITING("웨이팅 취소 처리가 불가한 상태입니다."),
     CAN_NOT_ENTRY("웨이팅을 입장 처리할 수 없습니다"),
-    WAITING_DOES_NOT_EXIST("웨이팅이 존재하지 않습니다"),
+    WAITING_DOES_NOT_EXIST("해당 아이디의 웨이팅이 존재하지 않습니다."),
+    WAITING_LINE_EMPTY("가게에 웨이팅이 존재하지 않습니다."),
     SHOP_NOT_RUNNING("가게가 영업시간이 아닙니다."),
     INTERNAL_SERVER_ERROR("내부 서버 오류입니다."),
 

--- a/src/main/java/com/prgrms/catchtable/waiting/controller/MemberWaitingController.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/controller/MemberWaitingController.java
@@ -1,6 +1,7 @@
 package com.prgrms.catchtable.waiting.controller;
 
 import com.prgrms.catchtable.waiting.dto.request.CreateWaitingRequest;
+import com.prgrms.catchtable.waiting.dto.response.MemberWaitingHistoryListResponse;
 import com.prgrms.catchtable.waiting.dto.response.MemberWaitingResponse;
 import com.prgrms.catchtable.waiting.service.MemberWaitingService;
 import jakarta.validation.Valid;
@@ -49,6 +50,13 @@ public class MemberWaitingController {
     public ResponseEntity<MemberWaitingResponse> getWaiting(
         @PathVariable("memberId") Long memberId) {
         MemberWaitingResponse response = memberWaitingService.getWaiting(memberId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/all/{memberId}")
+    public ResponseEntity<MemberWaitingHistoryListResponse> getMemberAllWaiting(
+        @PathVariable("memberId") Long memberId) {
+        MemberWaitingHistoryListResponse response = memberWaitingService.getMemberAllWaiting(memberId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/prgrms/catchtable/waiting/controller/MemberWaitingController.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/controller/MemberWaitingController.java
@@ -54,9 +54,9 @@ public class MemberWaitingController {
     }
 
     @GetMapping("/all/{memberId}")
-    public ResponseEntity<MemberWaitingHistoryListResponse> getMemberAllWaiting(
+    public ResponseEntity<MemberWaitingHistoryListResponse> getMemberWaitingHistory(
         @PathVariable("memberId") Long memberId) {
-        MemberWaitingHistoryListResponse response = memberWaitingService.getMemberAllWaiting(memberId);
+        MemberWaitingHistoryListResponse response = memberWaitingService.getMemberWaitingHistory(memberId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/prgrms/catchtable/waiting/controller/MemberWaitingController.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/controller/MemberWaitingController.java
@@ -56,7 +56,8 @@ public class MemberWaitingController {
     @GetMapping("/all/{memberId}")
     public ResponseEntity<MemberWaitingHistoryListResponse> getMemberWaitingHistory(
         @PathVariable("memberId") Long memberId) {
-        MemberWaitingHistoryListResponse response = memberWaitingService.getMemberWaitingHistory(memberId);
+        MemberWaitingHistoryListResponse response = memberWaitingService.getMemberWaitingHistory(
+            memberId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/prgrms/catchtable/waiting/controller/OwnerWaitingController.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/controller/OwnerWaitingController.java
@@ -1,10 +1,12 @@
 package com.prgrms.catchtable.waiting.controller;
 
 import com.prgrms.catchtable.waiting.dto.response.OwnerWaitingListResponse;
+import com.prgrms.catchtable.waiting.dto.response.OwnerWaitingResponse;
 import com.prgrms.catchtable.waiting.service.OwnerWaitingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,6 +22,12 @@ public class OwnerWaitingController {
     public ResponseEntity<OwnerWaitingListResponse> getOwnerAllWaiting(
         @PathVariable("ownerId") Long ownerId) {
         OwnerWaitingListResponse response = ownerWaitingService.getOwnerAllWaiting(ownerId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/{ownerId}")
+    public ResponseEntity<OwnerWaitingResponse> entryWaiting(@PathVariable("ownerId") Long ownerId){
+        OwnerWaitingResponse response = ownerWaitingService.entryWaiting(ownerId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/prgrms/catchtable/waiting/controller/OwnerWaitingController.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/controller/OwnerWaitingController.java
@@ -26,7 +26,8 @@ public class OwnerWaitingController {
     }
 
     @PatchMapping("/{ownerId}")
-    public ResponseEntity<OwnerWaitingResponse> entryWaiting(@PathVariable("ownerId") Long ownerId){
+    public ResponseEntity<OwnerWaitingResponse> entryWaiting(
+        @PathVariable("ownerId") Long ownerId) {
         OwnerWaitingResponse response = ownerWaitingService.entryWaiting(ownerId);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/prgrms/catchtable/waiting/domain/Waiting.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/domain/Waiting.java
@@ -50,7 +50,7 @@ public class Waiting extends BaseEntity {
     @Column(name = "remaining_postpone_count")
     private int remainingPostponeCount;
 
-    @OneToOne(fetch = LAZY)
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "member_id", foreignKey = @ForeignKey(NO_CONSTRAINT))
     private Member member;
 

--- a/src/main/java/com/prgrms/catchtable/waiting/domain/Waiting.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/domain/Waiting.java
@@ -22,7 +22,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/prgrms/catchtable/waiting/dto/WaitingMapper.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/dto/WaitingMapper.java
@@ -6,6 +6,8 @@ import com.prgrms.catchtable.member.domain.Member;
 import com.prgrms.catchtable.shop.domain.Shop;
 import com.prgrms.catchtable.waiting.domain.Waiting;
 import com.prgrms.catchtable.waiting.dto.request.CreateWaitingRequest;
+import com.prgrms.catchtable.waiting.dto.response.MemberWaitingHistoryListResponse;
+import com.prgrms.catchtable.waiting.dto.response.MemberWaitingHistoryResponse;
 import com.prgrms.catchtable.waiting.dto.response.MemberWaitingResponse;
 import com.prgrms.catchtable.waiting.dto.response.OwnerWaitingListResponse;
 import com.prgrms.catchtable.waiting.dto.response.OwnerWaitingResponse;
@@ -27,7 +29,7 @@ public class WaitingMapper {
     }
 
     // entity -> dto
-    public static MemberWaitingResponse toWaitingResponse(Waiting waiting, Long rank) {
+    public static MemberWaitingResponse toMemberWaitingResponse(Waiting waiting, Long rank) {
         return MemberWaitingResponse.builder()
             .waitingId(waiting.getId())
             .shopId(waiting.getShop().getId())
@@ -38,6 +40,25 @@ public class WaitingMapper {
             .remainingPostponeCount(waiting.getRemainingPostponeCount())
             .status(waiting.getStatus().getDescription())
             .build();
+    }
+
+    public static MemberWaitingHistoryResponse toMemberWaitingHistoryResponse(Waiting waiting) {
+        return MemberWaitingHistoryResponse.builder()
+            .waitingId(waiting.getId())
+            .shopId(waiting.getShop().getId())
+            .shopName(waiting.getShop().getName())
+            .peopleCount(waiting.getPeopleCount())
+            .waitingNumber(waiting.getWaitingNumber())
+            .status(waiting.getStatus().getDescription())
+            .build();
+    }
+
+    public static MemberWaitingHistoryListResponse toMemberWaitingListResponse(List<Waiting> waitings){
+        List<MemberWaitingHistoryResponse> list = new ArrayList<>();
+        for (Waiting waiting : waitings) {
+            list.add(toMemberWaitingHistoryResponse(waiting));
+        }
+        return new MemberWaitingHistoryListResponse(list);
     }
 
     public static OwnerWaitingResponse toOwnerWaitingResponse(Waiting waiting, Long rank) {

--- a/src/main/java/com/prgrms/catchtable/waiting/dto/WaitingMapper.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/dto/WaitingMapper.java
@@ -53,7 +53,8 @@ public class WaitingMapper {
             .build();
     }
 
-    public static MemberWaitingHistoryListResponse toMemberWaitingListResponse(List<Waiting> waitings){
+    public static MemberWaitingHistoryListResponse toMemberWaitingListResponse(
+        List<Waiting> waitings) {
         List<MemberWaitingHistoryResponse> list = new ArrayList<>();
         for (Waiting waiting : waitings) {
             list.add(toMemberWaitingHistoryResponse(waiting));

--- a/src/main/java/com/prgrms/catchtable/waiting/dto/response/MemberWaitingHistoryListResponse.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/dto/response/MemberWaitingHistoryListResponse.java
@@ -1,0 +1,8 @@
+package com.prgrms.catchtable.waiting.dto.response;
+
+import java.util.List;
+
+public record MemberWaitingHistoryListResponse(
+    List<MemberWaitingHistoryResponse> memberWaitings
+){
+}

--- a/src/main/java/com/prgrms/catchtable/waiting/dto/response/MemberWaitingHistoryListResponse.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/dto/response/MemberWaitingHistoryListResponse.java
@@ -4,5 +4,6 @@ import java.util.List;
 
 public record MemberWaitingHistoryListResponse(
     List<MemberWaitingHistoryResponse> memberWaitings
-){
+) {
+
 }

--- a/src/main/java/com/prgrms/catchtable/waiting/dto/response/MemberWaitingHistoryResponse.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/dto/response/MemberWaitingHistoryResponse.java
@@ -1,0 +1,13 @@
+package com.prgrms.catchtable.waiting.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record MemberWaitingHistoryResponse (
+    Long waitingId,
+    Long shopId,
+    String shopName,
+    int peopleCount,
+    int waitingNumber,
+    String status
+){}

--- a/src/main/java/com/prgrms/catchtable/waiting/dto/response/MemberWaitingHistoryResponse.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/dto/response/MemberWaitingHistoryResponse.java
@@ -3,11 +3,13 @@ package com.prgrms.catchtable.waiting.dto.response;
 import lombok.Builder;
 
 @Builder
-public record MemberWaitingHistoryResponse (
+public record MemberWaitingHistoryResponse(
     Long waitingId,
     Long shopId,
     String shopName,
     int peopleCount,
     int waitingNumber,
     String status
-){}
+) {
+
+}

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/WaitingRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/WaitingRepository.java
@@ -25,6 +25,8 @@ public interface WaitingRepository extends JpaRepository<Waiting, Long> {
     @Query("select w from Waiting w where w.id in :ids")
     List<Waiting> findByIds(@Param("ids") List<Long> ids);
 
-    @Query("select w from Waiting w join fetch w.member where w.id = :id")
-    Optional<Waiting> findWaitingWithMember(@Param("id") Long id);
+    @Query("select w from Waiting w "
+        + "join fetch w.shop "
+        + "join fetch w.member where w.member = :member")
+    List<Waiting> findWaitingWithMember(@Param("member") Member member);
 }

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepository.java
@@ -26,12 +26,9 @@ public class BasicWaitingLineRepository implements WaitingLineRepository {
         waitingLine.add(waitingId);
     }
 
-    public void entry(Long shopId, Long waitingId) {
+    public Long entry(Long shopId) {
         Queue<Long> waitingLine = waitingLines.get(shopId);
-        if (!Objects.equals(waitingLine.peek(), waitingId)) {
-            throw new BadRequestCustomException(CAN_NOT_ENTRY);
-        }
-        waitingLine.remove();
+        return waitingLine.remove();
     }
 
     public List<Long> getShopWaitingIdsInOrder(Long shopId) {

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepository.java
@@ -1,7 +1,6 @@
 package com.prgrms.catchtable.waiting.repository.waitingline;
 
 import static com.prgrms.catchtable.common.exception.ErrorCode.ALREADY_END_LINE;
-import static com.prgrms.catchtable.common.exception.ErrorCode.CAN_NOT_ENTRY;
 import static com.prgrms.catchtable.common.exception.ErrorCode.WAITING_DOES_NOT_EXIST;
 
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepository.java
@@ -2,6 +2,7 @@ package com.prgrms.catchtable.waiting.repository.waitingline;
 
 import static com.prgrms.catchtable.common.exception.ErrorCode.ALREADY_END_LINE;
 import static com.prgrms.catchtable.common.exception.ErrorCode.WAITING_DOES_NOT_EXIST;
+import static com.prgrms.catchtable.common.exception.ErrorCode.WAITING_LINE_EMPTY;
 
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
@@ -54,8 +55,8 @@ public class RedisWaitingLineRepository implements WaitingLineRepository {
             .toList());
     }
 
-    public void entry(Long shopId, Long waitingId) {
-        validateIfWaitingExists(shopId, waitingId);
+    public Long entry(Long shopId) {
+        Long waitingId = getShopWaitingIdsInOrder(shopId).get(0);
         redisTemplate.execute(new SessionCallback<>() {
             @Override
             public <K, V> Object execute(RedisOperations<K, V> operations)
@@ -70,8 +71,8 @@ public class RedisWaitingLineRepository implements WaitingLineRepository {
                 return operations.exec();
             }
         });
+        return waitingId;
     }
-
     public void cancel(Long shopId, Long waitingId) {
         validateIfWaitingExists(shopId, waitingId);
         redisTemplate.execute(new SessionCallback<>() {

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepository.java
@@ -2,7 +2,6 @@ package com.prgrms.catchtable.waiting.repository.waitingline;
 
 import static com.prgrms.catchtable.common.exception.ErrorCode.ALREADY_END_LINE;
 import static com.prgrms.catchtable.common.exception.ErrorCode.WAITING_DOES_NOT_EXIST;
-import static com.prgrms.catchtable.common.exception.ErrorCode.WAITING_LINE_EMPTY;
 
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
@@ -73,6 +72,7 @@ public class RedisWaitingLineRepository implements WaitingLineRepository {
         });
         return waitingId;
     }
+
     public void cancel(Long shopId, Long waitingId) {
         validateIfWaitingExists(shopId, waitingId);
         redisTemplate.execute(new SessionCallback<>() {

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/WaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/WaitingLineRepository.java
@@ -6,7 +6,7 @@ public interface WaitingLineRepository {
 
     void save(Long shopId, Long waitingId);
 
-    void entry(Long shopId, Long waitingId);
+    Long entry(Long shopId);
 
     void cancel(Long shopId, Long waitingId);
 

--- a/src/main/java/com/prgrms/catchtable/waiting/service/MemberWaitingService.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/service/MemberWaitingService.java
@@ -5,8 +5,9 @@ import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_MEMBER;
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_PROGRESS_WAITING;
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_SHOP;
 import static com.prgrms.catchtable.waiting.domain.WaitingStatus.PROGRESS;
+import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toMemberWaitingListResponse;
 import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toWaiting;
-import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toWaitingResponse;
+import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toMemberWaitingResponse;
 
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
@@ -16,12 +17,14 @@ import com.prgrms.catchtable.shop.domain.Shop;
 import com.prgrms.catchtable.shop.repository.ShopRepository;
 import com.prgrms.catchtable.waiting.domain.Waiting;
 import com.prgrms.catchtable.waiting.dto.request.CreateWaitingRequest;
+import com.prgrms.catchtable.waiting.dto.response.MemberWaitingHistoryListResponse;
 import com.prgrms.catchtable.waiting.dto.response.MemberWaitingResponse;
 import com.prgrms.catchtable.waiting.repository.WaitingRepository;
 import com.prgrms.catchtable.waiting.repository.waitingline.WaitingLineRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -59,7 +62,7 @@ public class MemberWaitingService {
         waitingLineRepository.save(shopId, waiting.getId());
         Long rank = waitingLineRepository.findRank(shopId, waiting.getId());
 
-        return toWaitingResponse(savedWaiting, rank);
+        return toMemberWaitingResponse(savedWaiting, rank);
     }
 
     @Transactional
@@ -73,7 +76,7 @@ public class MemberWaitingService {
         waitingLineRepository.postpone(shop.getId(), waiting.getId());
         Long rank = waitingLineRepository.findRank(shop.getId(), waiting.getId());
 
-        return toWaitingResponse(waiting, rank);
+        return toMemberWaitingResponse(waiting, rank);
     }
 
     @Transactional
@@ -85,7 +88,7 @@ public class MemberWaitingService {
         waitingLineRepository.cancel(shop.getId(), waiting.getId());
         waiting.changeStatusCanceled();
 
-        return toWaitingResponse(waiting, -1L);
+        return toMemberWaitingResponse(waiting, -1L);
     }
 
     @Transactional(readOnly = true)
@@ -96,7 +99,14 @@ public class MemberWaitingService {
         Shop shop = waiting.getShop();
         Long rank = waitingLineRepository.findRank(shop.getId(), waiting.getId());
 
-        return toWaitingResponse(waiting, rank);
+        return toMemberWaitingResponse(waiting, rank);
+    }
+
+    @Transactional(readOnly = true)
+    public MemberWaitingHistoryListResponse getMemberAllWaiting(Long memberId) {
+        Member member = getMemberEntity(memberId);
+        List<Waiting> waitings = waitingRepository.findWaitingWithMember(member);
+        return toMemberWaitingListResponse(waitings);
     }
 
 

--- a/src/main/java/com/prgrms/catchtable/waiting/service/MemberWaitingService.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/service/MemberWaitingService.java
@@ -6,8 +6,8 @@ import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_PROGRES
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_SHOP;
 import static com.prgrms.catchtable.waiting.domain.WaitingStatus.PROGRESS;
 import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toMemberWaitingListResponse;
-import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toWaiting;
 import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toMemberWaitingResponse;
+import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toWaiting;
 
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
@@ -103,7 +103,7 @@ public class MemberWaitingService {
     }
 
     @Transactional(readOnly = true)
-    public MemberWaitingHistoryListResponse getMemberAllWaiting(Long memberId) {
+    public MemberWaitingHistoryListResponse getMemberWaitingHistory(Long memberId) {
         Member member = getMemberEntity(memberId);
         List<Waiting> waitings = waitingRepository.findWaitingWithMember(member);
         return toMemberWaitingListResponse(waitings);

--- a/src/main/java/com/prgrms/catchtable/waiting/service/OwnerWaitingService.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/service/OwnerWaitingService.java
@@ -1,13 +1,17 @@
 package com.prgrms.catchtable.waiting.service;
 
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_OWNER;
+import static com.prgrms.catchtable.common.exception.ErrorCode.WAITING_DOES_NOT_EXIST;
 import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toOwnerWaitingListResponse;
+import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toOwnerWaitingResponse;
 
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
+import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
 import com.prgrms.catchtable.owner.domain.Owner;
 import com.prgrms.catchtable.owner.repository.OwnerRepository;
 import com.prgrms.catchtable.waiting.domain.Waiting;
 import com.prgrms.catchtable.waiting.dto.response.OwnerWaitingListResponse;
+import com.prgrms.catchtable.waiting.dto.response.OwnerWaitingResponse;
 import com.prgrms.catchtable.waiting.repository.WaitingRepository;
 import com.prgrms.catchtable.waiting.repository.waitingline.WaitingLineRepository;
 import java.util.List;
@@ -31,5 +35,16 @@ public class OwnerWaitingService {
             owner.getShop().getId());
         List<Waiting> waitings = waitingRepository.findByIds(waitingIds);
         return toOwnerWaitingListResponse(waitings);
+    }
+
+    @Transactional
+    public OwnerWaitingResponse entryWaiting(Long ownerId){
+        Owner owner = ownerRepository.findById(ownerId)
+            .orElseThrow(() -> new BadRequestCustomException(NOT_EXIST_OWNER));
+        Long enteredWaitingId = waitingLineRepository.entry(owner.getShop().getId());
+        Waiting waiting = waitingRepository.findById(enteredWaitingId)
+            .orElseThrow(() -> new NotFoundCustomException(WAITING_DOES_NOT_EXIST));
+        waiting.changeStatusCompleted();
+        return toOwnerWaitingResponse(waiting, 0L);
     }
 }

--- a/src/main/java/com/prgrms/catchtable/waiting/service/OwnerWaitingService.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/service/OwnerWaitingService.java
@@ -38,7 +38,7 @@ public class OwnerWaitingService {
     }
 
     @Transactional
-    public OwnerWaitingResponse entryWaiting(Long ownerId){
+    public OwnerWaitingResponse entryWaiting(Long ownerId) {
         Owner owner = ownerRepository.findById(ownerId)
             .orElseThrow(() -> new BadRequestCustomException(NOT_EXIST_OWNER));
         Long enteredWaitingId = waitingLineRepository.entry(owner.getShop().getId());

--- a/src/test/java/com/prgrms/catchtable/waiting/controller/OwnerWaitingControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/controller/OwnerWaitingControllerTest.java
@@ -1,6 +1,6 @@
 package com.prgrms.catchtable.waiting.controller;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -22,7 +22,6 @@ import com.prgrms.catchtable.waiting.domain.Waiting;
 import com.prgrms.catchtable.waiting.repository.WaitingRepository;
 import com.prgrms.catchtable.waiting.repository.waitingline.WaitingLineRepository;
 import java.util.List;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/prgrms/catchtable/waiting/fixture/WaitingFixture.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/fixture/WaitingFixture.java
@@ -6,7 +6,7 @@ import com.prgrms.catchtable.waiting.domain.Waiting;
 
 public class WaitingFixture {
 
-    public static Waiting waiting(Member member, Shop shop, int waitingNumber) {
+    public static Waiting progressWaiting(Member member, Shop shop, int waitingNumber) {
         return Waiting.builder()
             .member(member)
             .shop(shop)
@@ -16,8 +16,14 @@ public class WaitingFixture {
     }
 
     public static Waiting completedWaiting(Member member, Shop shop, int waitingNumber) {
-        Waiting waiting = waiting(member, shop, waitingNumber);
+        Waiting waiting = progressWaiting(member, shop, waitingNumber);
         waiting.changeStatusCompleted();
+        return waiting;
+    }
+
+    public static Waiting canceledWaiting(Member member, Shop shop, int waitingNumber) {
+        Waiting waiting = progressWaiting(member, shop, waitingNumber);
+        waiting.changeStatusCanceled();
         return waiting;
     }
 }

--- a/src/test/java/com/prgrms/catchtable/waiting/repository/WaitingRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/repository/WaitingRepositoryTest.java
@@ -1,6 +1,6 @@
 package com.prgrms.catchtable.waiting.repository;
 
-import static com.prgrms.catchtable.waiting.domain.WaitingStatus.*;
+import static com.prgrms.catchtable.waiting.domain.WaitingStatus.PROGRESS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.prgrms.catchtable.member.MemberFixture;
@@ -15,7 +15,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -122,6 +121,7 @@ class WaitingRepositoryTest {
         //when
         List<Waiting> memberAllWaitings = waitingRepository.findWaitingWithMember(member1);
         //then
-        assertThat(memberAllWaitings).containsExactly(canceledWaiting, completedWaiting, progressWaiting);
+        assertThat(memberAllWaitings).containsExactly(canceledWaiting, completedWaiting,
+            progressWaiting);
     }
 }

--- a/src/test/java/com/prgrms/catchtable/waiting/repository/WaitingRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/repository/WaitingRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.prgrms.catchtable.waiting.repository;
 
+import static com.prgrms.catchtable.waiting.domain.WaitingStatus.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.prgrms.catchtable.member.MemberFixture;
@@ -14,7 +15,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
-import org.assertj.core.api.Assertions;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -63,9 +64,10 @@ class WaitingRepositoryTest {
     @DisplayName("특정 가게의 당일 대기 번호를 조회할 수 있다.")
     @Test
     void countByShopAndCreatedAtBetween() {
-        Waiting yesterdayWaiting = WaitingFixture.waiting(member1, shop, 1);
+        //given
+        Waiting yesterdayWaiting = WaitingFixture.progressWaiting(member1, shop, 1);
         Waiting completedWaiting = WaitingFixture.completedWaiting(member2, shop, 2);
-        Waiting normalWaiting = WaitingFixture.waiting(member3, shop, 3);
+        Waiting normalWaiting = WaitingFixture.progressWaiting(member3, shop, 3);
         waitingRepository.saveAll(List.of(yesterdayWaiting, completedWaiting, normalWaiting));
 
         ReflectionTestUtils.setField(yesterdayWaiting, "createdAt",
@@ -79,17 +81,47 @@ class WaitingRepositoryTest {
         assertThat(count).isEqualTo(2L); //waiting2, waiting3
     }
 
-    @DisplayName("멤버의 아이디 리스트로 Waiting을 조회 가능하다.")
+    @DisplayName("멤버의 아이디 리스트로 waiting 목록을 조회 가능하다.")
     @Test
     void findByIdsWithMember() {
-        Waiting waiting1 = WaitingFixture.waiting(member1, shop, 1);
-        Waiting waiting2 = WaitingFixture.waiting(member2, shop, 2);
-        Waiting waiting3 = WaitingFixture.waiting(member3, shop, 3);
+        Waiting waiting1 = WaitingFixture.progressWaiting(member1, shop, 1);
+        Waiting waiting2 = WaitingFixture.progressWaiting(member2, shop, 2);
+        Waiting waiting3 = WaitingFixture.progressWaiting(member3, shop, 3);
         waitingRepository.saveAll(List.of(waiting1, waiting2, waiting3));
         List<Long> waitingIds = List.of(waiting1.getId(), waiting2.getId(), waiting3.getId());
         //when
         List<Waiting> waitings = waitingRepository.findByIds(waitingIds);
         //then
-        Assertions.assertThat(waitings).containsExactly(waiting1, waiting2, waiting3);
+        assertThat(waitings).containsExactly(waiting1, waiting2, waiting3);
+    }
+
+    @DisplayName("멤버의 진행 중인 웨이팅을 조회할 수 있다.")
+    @Test
+    void findByMemberAndStatusWithShop() {
+        //given
+        Waiting completedWaiting = WaitingFixture.completedWaiting(member1, shop, 1);
+        Waiting progressWaiting = WaitingFixture.progressWaiting(member1, shop, 2);
+        waitingRepository.saveAll(List.of(completedWaiting, progressWaiting));
+        //when
+        Waiting waiting = waitingRepository.findByMemberAndStatusWithShop(
+            member1, PROGRESS).orElseThrow();
+
+        //then
+        assertThat(waiting.getWaitingNumber()).isEqualTo(2);
+    }
+
+    @DisplayName("특정 멤버의 웨이팅 목록을 조회할 수 있다.")
+    @Test
+    void findWaitingWithMember() {
+        //given
+        Waiting canceledWaiting = WaitingFixture.canceledWaiting(member1, shop, 1);
+        Waiting completedWaiting = WaitingFixture.completedWaiting(member1, shop, 2);
+        Waiting progressWaiting = WaitingFixture.progressWaiting(member1, shop, 3);
+
+        waitingRepository.saveAll(List.of(canceledWaiting, completedWaiting, progressWaiting));
+        //when
+        List<Waiting> memberAllWaitings = waitingRepository.findWaitingWithMember(member1);
+        //then
+        assertThat(memberAllWaitings).containsExactly(canceledWaiting, completedWaiting, progressWaiting);
     }
 }

--- a/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepositoryTest.java
@@ -30,9 +30,10 @@ class BasicWaitingLineRepositoryTest {
         repository.save(shopId, 3L);
 
         //when
-        repository.entry(1L, 1L);
+        Long enteredWaitingId = repository.entry(1L);
 
         //then
+        assertThat(enteredWaitingId).isEqualTo(1L);
         assertThat(repository.findRank(1L, 1L))
             .isEqualTo(-1);
         assertThat(repository.findRank(1L, 2L))

--- a/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepositoryTest.java
@@ -52,10 +52,9 @@ class RedisWaitingLineRepositoryTest {
         repository.save(shopId, 3L);
 
         //when
-        repository.entry(1L, 1L);
+        repository.entry(1L);
 
         //then
-
         assertThrows(NotFoundCustomException.class,
             () -> repository.findRank(1L, 1L));
         assertThat(repository.findRank(1L, 2L))
@@ -134,5 +133,16 @@ class RedisWaitingLineRepositoryTest {
         //then
         System.out.println("waitingIds = " + waitingIds);
         assertThat(waitingIds.get(0)).isEqualTo(1L);
+    }
+
+    @DisplayName("웨이팅이 없으면 웨이팅 사이즈 0을 반환한다.")
+    @Test
+    void getWaitingLineSize(){
+        //given
+        Long shopId = 1L;
+        //when
+        Long waitingLineSize = repository.getWaitingLineSize(shopId);
+        //then
+        assertThat(waitingLineSize).isZero();
     }
 }

--- a/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepositoryTest.java
@@ -137,7 +137,7 @@ class RedisWaitingLineRepositoryTest {
 
     @DisplayName("웨이팅이 없으면 웨이팅 사이즈 0을 반환한다.")
     @Test
-    void getWaitingLineSize(){
+    void getWaitingLineSize() {
         //given
         Long shopId = 1L;
         //when

--- a/src/test/java/com/prgrms/catchtable/waiting/service/MemberWaitingServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/service/MemberWaitingServiceTest.java
@@ -16,10 +16,12 @@ import com.prgrms.catchtable.shop.domain.Shop;
 import com.prgrms.catchtable.shop.repository.ShopRepository;
 import com.prgrms.catchtable.waiting.domain.Waiting;
 import com.prgrms.catchtable.waiting.dto.request.CreateWaitingRequest;
+import com.prgrms.catchtable.waiting.dto.response.MemberWaitingHistoryListResponse;
 import com.prgrms.catchtable.waiting.dto.response.MemberWaitingResponse;
 import com.prgrms.catchtable.waiting.repository.WaitingRepository;
 import com.prgrms.catchtable.waiting.repository.waitingline.WaitingLineRepository;
 import java.time.LocalTime;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -129,7 +131,7 @@ class MemberWaitingServiceTest {
         );
     }
 
-    @DisplayName("점주의 웨이팅를 조회할 수 있다.")
+    @DisplayName("회원의 진행 중인 웨이팅를 조회할 수 있다.")
     @Test
     void getWaiting() {
         //given
@@ -153,5 +155,29 @@ class MemberWaitingServiceTest {
         );
     }
 
+    @DisplayName("회원의 웨이팅 목록을 모두 조회할 수 있다.")
+    @Test
+    void getMemberAllWaiting() {
+        //given
+        Member member = mock(Member.class);
+        Shop shop = mock(Shop.class);
+        Waiting waiting = mock(Waiting.class);
 
+        given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+        given(waitingRepository.findWaitingWithMember(member)).willReturn(
+            List.of(waiting));
+        given(waiting.getShop()).willReturn(shop);
+        given(waiting.getStatus()).willReturn(CANCELED);
+
+        //when
+        MemberWaitingHistoryListResponse response = memberWaitingService.getMemberAllWaiting(
+            1L);
+
+        //then
+        assertAll(
+            assertThat(response.memberWaitings().get(0).peopleCount())::isNotNull,
+            assertThat(response.memberWaitings().get(0).waitingNumber())::isNotNull,
+            assertThat(response.memberWaitings().get(0).status())::isNotNull
+        );
+    }
 }

--- a/src/test/java/com/prgrms/catchtable/waiting/service/MemberWaitingServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/service/MemberWaitingServiceTest.java
@@ -170,7 +170,7 @@ class MemberWaitingServiceTest {
         given(waiting.getStatus()).willReturn(CANCELED);
 
         //when
-        MemberWaitingHistoryListResponse response = memberWaitingService.getMemberAllWaiting(
+        MemberWaitingHistoryListResponse response = memberWaitingService.getMemberWaitingHistory(
             1L);
 
         //then

--- a/src/test/java/com/prgrms/catchtable/waiting/service/OwnerWaitingServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/service/OwnerWaitingServiceTest.java
@@ -1,6 +1,7 @@
 package com.prgrms.catchtable.waiting.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -62,15 +63,17 @@ class OwnerWaitingServiceTest {
         OwnerWaitingListResponse response = ownerWaitingService.getOwnerAllWaiting(1L);
 
         //then
-        assertThat(response.shopWaitings()).hasSize(2);
-
-        assertThat(response.shopWaitings().get(0).waitingId()).isEqualTo(waiting1.getId());
-        assertThat(response.shopWaitings().get(0).waitingNumber()).isEqualTo(
-            waiting1.getWaitingNumber());
-
-        assertThat(response.shopWaitings().get(1).waitingId()).isEqualTo(waiting2.getId());
-        assertThat(response.shopWaitings().get(1).waitingNumber()).isEqualTo(
-            waiting2.getWaitingNumber());
+        assertAll(
+            () -> assertThat(response.shopWaitings()).hasSize(2),
+            () -> assertThat(response.shopWaitings().get(0).waitingId())
+                .isEqualTo(waiting1.getId()),
+            () -> assertThat(response.shopWaitings().get(0).waitingNumber())
+                .isEqualTo(waiting1.getWaitingNumber()),
+            () -> assertThat(response.shopWaitings().get(1).waitingId())
+                .isEqualTo(waiting2.getId()),
+            () -> assertThat(response.shopWaitings().get(1).waitingNumber())
+                .isEqualTo(waiting2.getWaitingNumber())
+        );
     }
 
     @DisplayName("웨이팅 손님을 입장시킬 수 있다.")
@@ -89,10 +92,11 @@ class OwnerWaitingServiceTest {
         //when
         OwnerWaitingResponse response = ownerWaitingService.entryWaiting(1L);
         //then
-        assertThat(response.waitingId()).isEqualTo(waiting.getId());
-        assertThat(response.peopleCount()).isEqualTo(2);
-        assertThat(response.rank()).isZero();
-        assertThat(response.waitingNumber()).isEqualTo(waiting.getWaitingNumber());
-
+        assertAll(
+            () -> assertThat(response.waitingId()).isEqualTo(waiting.getId()),
+            () -> assertThat(response.peopleCount()).isEqualTo(2),
+            () -> assertThat(response.rank()).isZero(),
+            () -> assertThat(response.waitingNumber()).isEqualTo(waiting.getWaitingNumber())
+        );
     }
 }

--- a/src/test/java/com/prgrms/catchtable/waiting/service/OwnerWaitingServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/service/OwnerWaitingServiceTest.java
@@ -48,8 +48,8 @@ class OwnerWaitingServiceTest {
         Member member2 = mock(Member.class);
         Owner owner = mock(Owner.class);
         Shop shop = mock(Shop.class);
-        Waiting waiting1 = WaitingFixture.waiting(member1, shop, 1);
-        Waiting waiting2 = WaitingFixture.waiting(member2, shop, 2);
+        Waiting waiting1 = WaitingFixture.progressWaiting(member1, shop, 1);
+        Waiting waiting2 = WaitingFixture.progressWaiting(member2, shop, 2);
 
         given(ownerRepository.findById(1L)).willReturn(Optional.of(owner));
         given(owner.getShop()).willReturn(shop);
@@ -80,7 +80,7 @@ class OwnerWaitingServiceTest {
         Member member = mock(Member.class);
         Owner owner = mock(Owner.class);
         Shop shop = mock(Shop.class);
-        Waiting waiting = WaitingFixture.waiting(member, shop, 1);
+        Waiting waiting = WaitingFixture.progressWaiting(member, shop, 1);
 
         given(ownerRepository.findById(1L)).willReturn(Optional.of(owner));
         given(owner.getShop()).willReturn(shop);

--- a/src/test/java/com/prgrms/catchtable/waiting/service/OwnerWaitingServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/service/OwnerWaitingServiceTest.java
@@ -11,6 +11,7 @@ import com.prgrms.catchtable.owner.repository.OwnerRepository;
 import com.prgrms.catchtable.shop.domain.Shop;
 import com.prgrms.catchtable.waiting.domain.Waiting;
 import com.prgrms.catchtable.waiting.dto.response.OwnerWaitingListResponse;
+import com.prgrms.catchtable.waiting.dto.response.OwnerWaitingResponse;
 import com.prgrms.catchtable.waiting.fixture.WaitingFixture;
 import com.prgrms.catchtable.waiting.repository.WaitingRepository;
 import com.prgrms.catchtable.waiting.repository.waitingline.WaitingLineRepository;
@@ -70,5 +71,28 @@ class OwnerWaitingServiceTest {
         assertThat(response.shopWaitings().get(1).waitingId()).isEqualTo(waiting2.getId());
         assertThat(response.shopWaitings().get(1).waitingNumber()).isEqualTo(
             waiting2.getWaitingNumber());
+    }
+
+    @DisplayName("웨이팅 손님을 입장시킬 수 있다.")
+    @Test
+    void entryWaiting() {
+        //given
+        Member member = mock(Member.class);
+        Owner owner = mock(Owner.class);
+        Shop shop = mock(Shop.class);
+        Waiting waiting = WaitingFixture.waiting(member, shop, 1);
+
+        given(ownerRepository.findById(1L)).willReturn(Optional.of(owner));
+        given(owner.getShop()).willReturn(shop);
+        given(waitingLineRepository.entry(any(Long.class))).willReturn(1L);
+        given(waitingRepository.findById(1L)).willReturn(Optional.of(waiting));
+        //when
+        OwnerWaitingResponse response = ownerWaitingService.entryWaiting(1L);
+        //then
+        assertThat(response.waitingId()).isEqualTo(waiting.getId());
+        assertThat(response.peopleCount()).isEqualTo(2);
+        assertThat(response.rank()).isZero();
+        assertThat(response.waitingNumber()).isEqualTo(waiting.getWaitingNumber());
+
     }
 }


### PR DESCRIPTION
### ⛏ 작업 상세 내용

- 연관관계 수정
  - member, waiting 일대일 -> 다대일
- 테스트 작성
  - 통합 테스트, 서비스 및 리포지토리 단위 테스트 
 - 응답 dto 및 mapper 기능 추가
- 기존 단위 테스트 리팩토링

### 📝 작업 요약

- 유저 웨이팅 이력 조회 API 구현
- 통합 테스트, 단위 테스트 작성

### **☑️** 중점적으로 리뷰 할 부분

- 컨트롤러, 서비스 메소드 네이밍
