### PR TITLE
feat : 예약과 회원 연관관계 매핑

### DIFF
--- a/src/main/java/com/prgrms/catchtable/common/login/WebConfig.java
+++ b/src/main/java/com/prgrms/catchtable/common/login/WebConfig.java
@@ -9,7 +9,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebConfig implements WebMvcConfigurer {
 
     @Override
-    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers){
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(new LogInArgumentResolver());
     }
 

--- a/src/main/java/com/prgrms/catchtable/reservation/controller/MemberReservationController.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/controller/MemberReservationController.java
@@ -1,5 +1,7 @@
 package com.prgrms.catchtable.reservation.controller;
 
+import com.prgrms.catchtable.common.login.LogIn;
+import com.prgrms.catchtable.member.domain.Member;
 import com.prgrms.catchtable.reservation.dto.request.CreateReservationRequest;
 import com.prgrms.catchtable.reservation.dto.request.ModifyReservationRequest;
 import com.prgrms.catchtable.reservation.dto.response.CancelReservationResponse;
@@ -28,14 +30,16 @@ public class MemberReservationController {
 
     @PostMapping
     public ResponseEntity<CreateReservationResponse> preOccupyReservation(
+        @LogIn Member member,
         @RequestBody CreateReservationRequest request) {
-        return ResponseEntity.ok(memberReservationService.preOccupyReservation(request));
+        return ResponseEntity.ok(memberReservationService.preOccupyReservation(member, request));
     }
 
     @PostMapping("/success")
     public ResponseEntity<CreateReservationResponse> registerReservation(
+        @LogIn Member member,
         @RequestBody CreateReservationRequest request) {
-        return ResponseEntity.ok(memberReservationService.registerReservation(request));
+        return ResponseEntity.ok(memberReservationService.registerReservation(member, request));
     }
 
     @PatchMapping("/{reservationId}")

--- a/src/main/java/com/prgrms/catchtable/reservation/controller/MemberReservationController.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/controller/MemberReservationController.java
@@ -57,7 +57,7 @@ public class MemberReservationController {
     }
 
     @GetMapping
-    public ResponseEntity<List<GetAllReservationResponse>> getAllReservation() {
-        return ResponseEntity.ok(memberReservationService.getAllReservation());
+    public ResponseEntity<List<GetAllReservationResponse>> getAllReservation(@LogIn Member member) {
+        return ResponseEntity.ok(memberReservationService.getAllReservation(member));
     }
 }

--- a/src/main/java/com/prgrms/catchtable/reservation/domain/Reservation.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/domain/Reservation.java
@@ -53,11 +53,12 @@ public class Reservation extends BaseEntity {
 
     @Builder
     public Reservation(ReservationStatus status, int peopleCount,
-        ReservationTime reservationTime) {
+        ReservationTime reservationTime, Member member) {
         this.status = status;
         this.peopleCount = peopleCount;
         this.reservationTime = reservationTime;
         this.shop = reservationTime.getShop();
+        this.member = member;
     }
 
     public void modifyReservation(ReservationTime reservationTime, int peopleCount) {

--- a/src/main/java/com/prgrms/catchtable/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/repository/ReservationRepository.java
@@ -1,5 +1,6 @@
 package com.prgrms.catchtable.reservation.repository;
 
+import com.prgrms.catchtable.member.domain.Member;
 import com.prgrms.catchtable.reservation.domain.Reservation;
 import java.util.List;
 import java.util.Optional;
@@ -11,8 +12,9 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     @Query("select r from Reservation r "
         + "join fetch r.reservationTime rt "
-        + "join fetch rt.shop")
-    List<Reservation> findAllWithReservationTimeAndShop();
+        + "join fetch rt.shop "
+        + "where r.member = :member")
+    List<Reservation> findAllWithReservationTimeAndShopByMemberId(@Param("member") Member member);
 
     @Query("select r from Reservation r "
         + "join fetch r.reservationTime rt "

--- a/src/main/java/com/prgrms/catchtable/reservation/service/MemberReservationService.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/service/MemberReservationService.java
@@ -42,7 +42,8 @@ public class MemberReservationService {
     private final ReservationLockRepository reservationLockRepository;
 
     @Transactional
-    public CreateReservationResponse preOccupyReservation(Member member, CreateReservationRequest request) {
+    public CreateReservationResponse preOccupyReservation(Member member,
+        CreateReservationRequest request) {
         Long reservationTimeId = request.reservationTimeId();
         while (FALSE.equals(reservationLockRepository.lock(reservationTimeId))) {
             try {
@@ -73,7 +74,8 @@ public class MemberReservationService {
     }
 
     @Transactional
-    public CreateReservationResponse registerReservation(Member member, CreateReservationRequest request) {
+    public CreateReservationResponse registerReservation(Member member,
+        CreateReservationRequest request) {
         ReservationTime reservationTime = reservationTimeRepository.findByIdWithShop(
                 request.reservationTimeId()).
             orElseThrow(() -> new NotFoundCustomException(NOT_EXIST_TIME));
@@ -94,7 +96,8 @@ public class MemberReservationService {
 
     @Transactional(readOnly = true)
     public List<GetAllReservationResponse> getAllReservation(Member member) {
-        List<Reservation> reservations = reservationRepository.findAllWithReservationTimeAndShopByMemberId(member);
+        List<Reservation> reservations = reservationRepository.findAllWithReservationTimeAndShopByMemberId(
+            member);
         return reservations.stream()
             .map(ReservationMapper::toGetAllReservationRepsonse)
             .toList();

--- a/src/main/java/com/prgrms/catchtable/reservation/service/MemberReservationService.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/service/MemberReservationService.java
@@ -93,8 +93,8 @@ public class MemberReservationService {
     }
 
     @Transactional(readOnly = true)
-    public List<GetAllReservationResponse> getAllReservation() {
-        List<Reservation> reservations = reservationRepository.findAllWithReservationTimeAndShop();
+    public List<GetAllReservationResponse> getAllReservation(Member member) {
+        List<Reservation> reservations = reservationRepository.findAllWithReservationTimeAndShopByMemberId(member);
         return reservations.stream()
             .map(ReservationMapper::toGetAllReservationRepsonse)
             .toList();

--- a/src/main/java/com/prgrms/catchtable/reservation/service/MemberReservationService.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/service/MemberReservationService.java
@@ -13,6 +13,7 @@ import static java.lang.Boolean.FALSE;
 
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
+import com.prgrms.catchtable.member.domain.Member;
 import com.prgrms.catchtable.reservation.domain.Reservation;
 import com.prgrms.catchtable.reservation.domain.ReservationTime;
 import com.prgrms.catchtable.reservation.dto.mapper.ReservationMapper;
@@ -41,7 +42,7 @@ public class MemberReservationService {
     private final ReservationLockRepository reservationLockRepository;
 
     @Transactional
-    public CreateReservationResponse preOccupyReservation(CreateReservationRequest request) {
+    public CreateReservationResponse preOccupyReservation(Member member, CreateReservationRequest request) {
         Long reservationTimeId = request.reservationTimeId();
         while (FALSE.equals(reservationLockRepository.lock(reservationTimeId))) {
             try {
@@ -65,14 +66,14 @@ public class MemberReservationService {
 
         return CreateReservationResponse.builder()
             .shopName(shop.getName())
-            .memberName("memberA")
+            .memberName(member.getName())
             .date(reservationTime.getTime())
             .peopleCount(request.peopleCount())
             .build();
     }
 
     @Transactional
-    public CreateReservationResponse registerReservation(CreateReservationRequest request) {
+    public CreateReservationResponse registerReservation(Member member, CreateReservationRequest request) {
         ReservationTime reservationTime = reservationTimeRepository.findByIdWithShop(
                 request.reservationTimeId()).
             orElseThrow(() -> new NotFoundCustomException(NOT_EXIST_TIME));
@@ -85,6 +86,7 @@ public class MemberReservationService {
             .status(COMPLETED)
             .peopleCount(request.peopleCount())
             .reservationTime(reservationTime)
+            .member(member)
             .build();
         Reservation savedReservation = reservationRepository.save(reservation);
         return toCreateReservationResponse(savedReservation);

--- a/src/test/java/com/prgrms/catchtable/common/base/BaseIntegrationTest.java
+++ b/src/test/java/com/prgrms/catchtable/common/base/BaseIntegrationTest.java
@@ -2,16 +2,24 @@ package com.prgrms.catchtable.common.base;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.prgrms.catchtable.jwt.provider.JwtTokenProvider;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 public abstract class BaseIntegrationTest {
 
+    @Autowired
+    public JwtTokenProvider jwtTokenProvider;
+
     public static ObjectMapper objectMapper = new ObjectMapper();
+
+    public HttpHeaders httpHeaders = new HttpHeaders();
     @Autowired
     public MockMvc mockMvc;
 

--- a/src/test/java/com/prgrms/catchtable/common/base/BaseIntegrationTest.java
+++ b/src/test/java/com/prgrms/catchtable/common/base/BaseIntegrationTest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.prgrms.catchtable.jwt.provider.JwtTokenProvider;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;

--- a/src/test/java/com/prgrms/catchtable/owner/service/OwnerServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/owner/service/OwnerServiceTest.java
@@ -79,7 +79,8 @@ class OwnerServiceTest {
         //given
         LoginOwnerRequest loginOwnerRequest = OwnerFixture.getLoginOwnerRequest(email, password);
         String encodePassword = passwordEncoder.encode(password);
-        Token token = new Token("AccessToken", "RefreshToken", loginOwnerRequest.email(), Role.OWNER);
+        Token token = new Token("AccessToken", "RefreshToken", loginOwnerRequest.email(),
+            Role.OWNER);
 
         //when
         when(ownerRepository.findOwnerByEmail(loginOwnerRequest.email())).thenReturn(

--- a/src/test/java/com/prgrms/catchtable/reservation/controller/MemberReservationControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/controller/MemberReservationControllerTest.java
@@ -47,14 +47,14 @@ class MemberReservationControllerTest extends BaseIntegrationTest {
     private ReservationRepository reservationRepository;
     @Autowired
     private MemberRepository memberRepository;
-
+    private Member member = MemberFixture.member("dlswns661035@gmail.com");
 
     @BeforeEach
     void setUp() {
         Shop shop = ShopData.getShop();
         Shop savedShop = shopRepository.save(shop);
 
-        Member member = MemberFixture.member("dlswns661035@gmail.com");
+
         Member savedMember = memberRepository.save(member);
 
         ReservationTime reservationTime = ReservationFixture.getReservationTimeNotPreOccupied();
@@ -81,6 +81,7 @@ class MemberReservationControllerTest extends BaseIntegrationTest {
                 .content(asJsonString(request)))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.shopName").value(reservationTime.getShop().getName()))
+            .andExpect(jsonPath("$.memberName").value(member.getName()))
             .andExpect(jsonPath("$.date").value(reservationTime.getTime().toString()))
             .andExpect(jsonPath("$.peopleCount").value(request.peopleCount()));
     }
@@ -122,8 +123,11 @@ class MemberReservationControllerTest extends BaseIntegrationTest {
             .andExpect(jsonPath("$.shopName").value(reservationTime.getShop().getName()))
             .andExpect(jsonPath("$.date").value(reservationTime.getTime().toString()))
             .andExpect(jsonPath("$.peopleCount").value(request.peopleCount()));
-
+        Reservation reservation = reservationRepository.findAllWithReservationTimeAndShopByMemberId(
+            member).get(0);
         assertThat(reservationTime.isOccupied()).isTrue();
+        assertThat(reservation.getReservationTime()).isEqualTo(reservationTime);
+        assertThat(reservation.getShop()).isEqualTo(reservationTime.getShop());
     }
 
     @Test

--- a/src/test/java/com/prgrms/catchtable/reservation/controller/MemberReservationControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/controller/MemberReservationControllerTest.java
@@ -1,19 +1,17 @@
 package com.prgrms.catchtable.reservation.controller;
 
-import static com.prgrms.catchtable.common.Role.*;
+import static com.prgrms.catchtable.common.Role.MEMBER;
 import static com.prgrms.catchtable.common.exception.ErrorCode.ALREADY_OCCUPIED_RESERVATION_TIME;
 import static com.prgrms.catchtable.reservation.domain.ReservationStatus.CANCELLED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.head;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.prgrms.catchtable.common.Role;
 import com.prgrms.catchtable.common.base.BaseIntegrationTest;
 import com.prgrms.catchtable.common.data.shop.ShopData;
 import com.prgrms.catchtable.jwt.token.Token;
@@ -51,7 +49,6 @@ class MemberReservationControllerTest extends BaseIntegrationTest {
     private MemberRepository memberRepository;
 
 
-
     @BeforeEach
     void setUp() {
         Shop shop = ShopData.getShop();
@@ -66,7 +63,7 @@ class MemberReservationControllerTest extends BaseIntegrationTest {
 
         Token token = jwtTokenProvider.createToken(savedMember.getEmail(), MEMBER);
         httpHeaders.add("AccessToken", token.getAccessToken());
-        httpHeaders.add("RefreshToken",token.getRefreshToken());
+        httpHeaders.add("RefreshToken", token.getRefreshToken());
     }
 
     @Test
@@ -99,7 +96,7 @@ class MemberReservationControllerTest extends BaseIntegrationTest {
             reservationTime.getId());
 
         mockMvc.perform(post("/reservations")
-                .headers(httpHeaders)
+            .headers(httpHeaders)
             .contentType(APPLICATION_JSON)
             .content(asJsonString(request)));
 

--- a/src/test/java/com/prgrms/catchtable/reservation/fixture/ReservationFixture.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/fixture/ReservationFixture.java
@@ -3,6 +3,7 @@ package com.prgrms.catchtable.reservation.fixture;
 import static com.prgrms.catchtable.reservation.domain.ReservationStatus.COMPLETED;
 
 import com.prgrms.catchtable.common.data.shop.ShopData;
+import com.prgrms.catchtable.member.domain.Member;
 import com.prgrms.catchtable.reservation.domain.Reservation;
 import com.prgrms.catchtable.reservation.domain.ReservationStatus;
 import com.prgrms.catchtable.reservation.domain.ReservationTime;
@@ -92,6 +93,18 @@ public class ReservationFixture {
         ReservationStatus status) {
         return ModifyReservationStatusRequest.builder()
             .status(status)
+            .build();
+    }
+
+    public static Reservation getReservation(ReservationTime reservationTime, Member member) {
+        if (!reservationTime.isOccupied()) {
+            reservationTime.setOccupiedTrue();
+        }
+        return Reservation.builder()
+            .status(COMPLETED)
+            .peopleCount(4)
+            .reservationTime(reservationTime)
+            .member(member)
             .build();
     }
 

--- a/src/test/java/com/prgrms/catchtable/reservation/repository/ReservationRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/repository/ReservationRepositoryTest.java
@@ -49,7 +49,8 @@ class ReservationRepositoryTest {
         Reservation reservation = ReservationFixture.getReservation(savedReservationTime, member);
         reservationRepository.save(reservation);
 
-        List<Reservation> reservations = reservationRepository.findAllWithReservationTimeAndShopByMemberId(savedMember);
+        List<Reservation> reservations = reservationRepository.findAllWithReservationTimeAndShopByMemberId(
+            savedMember);
         Reservation findReservation = reservations.get(0);
 
         assertAll(

--- a/src/test/java/com/prgrms/catchtable/reservation/service/MemberReservationServiceIntegrationTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/service/MemberReservationServiceIntegrationTest.java
@@ -4,6 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.prgrms.catchtable.common.data.shop.ShopData;
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
+import com.prgrms.catchtable.member.MemberFixture;
+import com.prgrms.catchtable.member.domain.Member;
+import com.prgrms.catchtable.member.repository.MemberRepository;
 import com.prgrms.catchtable.reservation.domain.ReservationTime;
 import com.prgrms.catchtable.reservation.dto.request.CreateReservationRequest;
 import com.prgrms.catchtable.reservation.fixture.ReservationFixture;
@@ -33,10 +36,17 @@ public class MemberReservationServiceIntegrationTest {
     @Autowired
     private ShopRepository shopRepository;
 
+    @Autowired
+    private MemberRepository memberRepository;
+
     @BeforeEach
     void setUp() {
         Shop shop = ShopData.getShop();
         Shop savedShop = shopRepository.save(shop);
+
+        Member member = MemberFixture.member("dlswns661035@gmail.com");
+        memberRepository.save(member);
+
 
         ReservationTime reservationTime = ReservationFixture.getReservationTimeNotPreOccupied();
         reservationTime.insertShop(savedShop);
@@ -46,6 +56,7 @@ public class MemberReservationServiceIntegrationTest {
     @Test
     @DisplayName("동시에 요청이 들어오면 하나만 선점권이 true로 바뀌고 나머진 예외가 발생한다.")
     void concurrencyTest() throws InterruptedException {
+        Member member = memberRepository.findAll().get(0);
         AtomicInteger errorCount = new AtomicInteger(0);
 
         List<ReservationTime> all = reservationTimeRepository.findAll();
@@ -60,7 +71,7 @@ public class MemberReservationServiceIntegrationTest {
         for (int i = 0; i < threadCount; i++) {
             executorService.submit(() -> {
                 try {
-                    memberReservationService.preOccupyReservation(request);
+                    memberReservationService.preOccupyReservation(member, request);
                 } catch (BadRequestCustomException e) {
                     errorCount.incrementAndGet();
                 } finally {

--- a/src/test/java/com/prgrms/catchtable/reservation/service/MemberReservationServiceIntegrationTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/service/MemberReservationServiceIntegrationTest.java
@@ -19,7 +19,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,7 +45,6 @@ public class MemberReservationServiceIntegrationTest {
 
         Member member = MemberFixture.member("dlswns661035@gmail.com");
         memberRepository.save(member);
-
 
         ReservationTime reservationTime = ReservationFixture.getReservationTimeNotPreOccupied();
         reservationTime.insertShop(savedShop);

--- a/src/test/java/com/prgrms/catchtable/reservation/service/MemberReservationServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/service/MemberReservationServiceTest.java
@@ -51,12 +51,13 @@ class MemberReservationServiceTest {
     private ReservationTimeRepository reservationTimeRepository;
     @InjectMocks
     private MemberReservationService memberReservationService;
+    private final String email = "dlswns661035@gmail.com";
 
     @Test
     @DisplayName("예약시간의 선점 여부를 검증하고 선점권이 빈 것을 확인한다.")
     void validateReservation() {
         //given
-        Member member = MemberFixture.member("dlswns661035@gmail.com");
+        Member member = MemberFixture.member(email);
         ReservationTime reservationTime = ReservationFixture.getReservationTimeNotPreOccupied();
         ReflectionTestUtils.setField(reservationTime, "id", 1L);
         CreateReservationRequest request = ReservationFixture.getCreateReservationRequestWithId(
@@ -84,7 +85,7 @@ class MemberReservationServiceTest {
     @DisplayName("예약시간 선점권이 이미 타인에게 있는 경우 예외가 발생한다.")
     void alreadyPreOccupied() {
         //given
-        Member member = MemberFixture.member("dlswns661035@gmail.com");
+        Member member = MemberFixture.member(email);
         ReservationTime reservationTime = ReservationFixture.getReservationTimePreOccupied();
         ReflectionTestUtils.setField(reservationTime, "id", 1L);
         CreateReservationRequest request = ReservationFixture.getCreateReservationRequestWithId(
@@ -103,7 +104,7 @@ class MemberReservationServiceTest {
     @Test
     @DisplayName("최종예약을 등록할 때 예약시간이 비었으면 성공적으로 예약 등록을 완료한다.")
     void registerReservation() {
-        Member member = MemberFixture.member("dlswns661035@gmail.com");
+        Member member = MemberFixture.member(email);
         ReservationTime reservationTime = ReservationFixture.getReservationTimePreOccupied();
         CreateReservationRequest request = ReservationFixture.getCreateReservationRequest();
         Reservation reservation = Reservation.builder()
@@ -130,7 +131,7 @@ class MemberReservationServiceTest {
     @Test
     @DisplayName("최종예약을 등록할 때 타인이 이미 예약한 경우 예외가 발생한다.")
     void registerReservationAlreadyOccupied() {
-        Member member = MemberFixture.member("dlswns661035@gmail.com");
+        Member member = MemberFixture.member(email);
         ReservationTime reservationTime = ReservationFixture.getReservationTimePreOccupied();
         CreateReservationRequest request = ReservationFixture.getCreateReservationRequest();
 
@@ -145,7 +146,7 @@ class MemberReservationServiceTest {
     @Test
     @DisplayName("예약 전체 조회를 할 수 있다")
     void getAllReservation() {
-        Member member = MemberFixture.member("dlswns661035@gmail.com");
+        Member member = MemberFixture.member(email);
 
         ReservationTime reservationTime = ReservationFixture.getReservationTimeNotPreOccupied();
         Reservation reservation = ReservationFixture.getReservation(reservationTime, member);
@@ -167,7 +168,7 @@ class MemberReservationServiceTest {
     @Test
     @DisplayName("예약 내역이 하나도 없을 시 조회되는 예약이 없다.")
     void getAllReservationWithNoResult() {
-        Member member = MemberFixture.member("dlswns661035@gmail.com");
+        Member member = MemberFixture.member(email);
         when(reservationRepository.findAllWithReservationTimeAndShopByMemberId(member)).thenReturn(
             List.of());
 

--- a/src/test/java/com/prgrms/catchtable/reservation/service/MemberReservationServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/service/MemberReservationServiceTest.java
@@ -117,7 +117,8 @@ class MemberReservationServiceTest {
             Optional.of(reservationTime));
         when(reservationRepository.save(any(Reservation.class))).thenReturn(reservation);
 
-        CreateReservationResponse response = memberReservationService.registerReservation(member, request);
+        CreateReservationResponse response = memberReservationService.registerReservation(member,
+            request);
 
         assertAll(
             () -> assertThat(response.date()).isEqualTo(reservationTime.getTime()),
@@ -147,7 +148,7 @@ class MemberReservationServiceTest {
         Member member = MemberFixture.member("dlswns661035@gmail.com");
 
         ReservationTime reservationTime = ReservationFixture.getReservationTimeNotPreOccupied();
-        Reservation reservation = ReservationFixture.getReservation(reservationTime,member);
+        Reservation reservation = ReservationFixture.getReservation(reservationTime, member);
 
         when(reservationRepository.findAllWithReservationTimeAndShopByMemberId(member)).thenReturn(
             List.of(reservation));
@@ -167,7 +168,8 @@ class MemberReservationServiceTest {
     @DisplayName("예약 내역이 하나도 없을 시 조회되는 예약이 없다.")
     void getAllReservationWithNoResult() {
         Member member = MemberFixture.member("dlswns661035@gmail.com");
-        when(reservationRepository.findAllWithReservationTimeAndShopByMemberId(member)).thenReturn(List.of());
+        when(reservationRepository.findAllWithReservationTimeAndShopByMemberId(member)).thenReturn(
+            List.of());
 
         List<GetAllReservationResponse> all = memberReservationService.getAllReservation(member);
         assertThat(all).isEmpty();

--- a/src/test/java/com/prgrms/catchtable/reservation/service/MemberReservationServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/service/MemberReservationServiceTest.java
@@ -144,12 +144,14 @@ class MemberReservationServiceTest {
     @Test
     @DisplayName("예약 전체 조회를 할 수 있다")
     void getAllReservation() {
-        ReservationTime reservationTime = ReservationFixture.getReservationTimeNotPreOccupied();
-        Reservation reservation = ReservationFixture.getReservation(reservationTime);
+        Member member = MemberFixture.member("dlswns661035@gmail.com");
 
-        when(reservationRepository.findAllWithReservationTimeAndShop()).thenReturn(
+        ReservationTime reservationTime = ReservationFixture.getReservationTimeNotPreOccupied();
+        Reservation reservation = ReservationFixture.getReservation(reservationTime,member);
+
+        when(reservationRepository.findAllWithReservationTimeAndShopByMemberId(member)).thenReturn(
             List.of(reservation));
-        List<GetAllReservationResponse> all = memberReservationService.getAllReservation();
+        List<GetAllReservationResponse> all = memberReservationService.getAllReservation(member);
         GetAllReservationResponse findReservation = all.get(0);
 
         assertAll(
@@ -164,9 +166,10 @@ class MemberReservationServiceTest {
     @Test
     @DisplayName("예약 내역이 하나도 없을 시 조회되는 예약이 없다.")
     void getAllReservationWithNoResult() {
-        when(reservationRepository.findAllWithReservationTimeAndShop()).thenReturn(List.of());
+        Member member = MemberFixture.member("dlswns661035@gmail.com");
+        when(reservationRepository.findAllWithReservationTimeAndShopByMemberId(member)).thenReturn(List.of());
 
-        List<GetAllReservationResponse> all = memberReservationService.getAllReservation();
+        List<GetAllReservationResponse> all = memberReservationService.getAllReservation(member);
         assertThat(all).isEmpty();
     }
 


### PR DESCRIPTION
close #64 
### ⛏ 작업 상세 내용

- Reservation
    - 예약 생성시에 회원을 받는 것으로 생성자 변경했습니다. 예약엔 회원이 꼭 있어야 하기 때문에!
- MemberReservationService, ReservationRepository
    - 예약 선점, 등록, 조회 시 요청한 회원에 대한 것만 등록, 조회 하도록 수정하였습니다. 
    - 기존 쿼리는 예약을 그냥 다 가져오는거였는데 쿼리 조건에 회원아이디와 일치하는 예약을 가져오는 것으로 쿼리 수정했습니다. 
 - 수정한 것에 대해서 테스트 코드도 전부 수정하였습니다.
 - BaseIntegrationTest
     - 컨트롤러 통합 테스트 시 토큰이 필요하기 때문에 이에 필요한 헤더, 토큰 관련 의존성 추가했습니다.
     - 컨트롤러 테스트 시 활용하면 됩니다! MemberReservationControllerTest 보고 참고하시면 됩니다.

### 📝 작업 요약

- 예약-회원 연관관계 매핑 및 테스트

### **☑️** 중점적으로 리뷰 할 부분

- BaseIntegrationTest 추가된 내용
- 수정된 쿼리
- 수정된 로직
