### PR TITLE
feat : 예약 알림 기능 추가

### DIFF
--- a/src/main/java/com/prgrms/catchtable/common/notification/NotificationContent.java
+++ b/src/main/java/com/prgrms/catchtable/common/notification/NotificationContent.java
@@ -1,6 +1,5 @@
 package com.prgrms.catchtable.common.notification;
 
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +15,7 @@ public enum NotificationContent {
 
     private final Function<String, String> expression;
 
-    public String apply(String time){
+    public String apply(String time) {
         return expression.apply(time);
     }
 

--- a/src/main/java/com/prgrms/catchtable/common/notification/NotificationContent.java
+++ b/src/main/java/com/prgrms/catchtable/common/notification/NotificationContent.java
@@ -1,20 +1,23 @@
 package com.prgrms.catchtable.common.notification;
 
+import java.util.function.BiFunction;
+import java.util.function.Function;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Getter
 public enum NotificationContent {
-    RESERVATION_COMPLETED("예약이 완료되었습니다"),
-    RESERVATION_ONE_HOUR_LEFT("예약 시간 1시간 전입니다."),
-    RESERVATION_TIME_TO_ENTER("예약시간이 되었습니다"),
-    WAITING_REGISTER_COMPLETED("웨이팅 등록이 완료되었습니다"),
-    WAITING_RANK_THIRD("웨이팅 순서가 3번째가 되었습니다"),
-    WAITING_TIME_TO_ENTER("웨이팅이 끝났습니다. 입장 부탁드립니다."),
-    WAITING_CANCELLED_AUTOMATICALLY("웨이팅이 자동으로 취소되었습니다.");
+    RESERVATION_COMPLETED(time -> time.concat(" 시간의 예약이 완료 되었습니다.")),
+    RESERVATION_CANCELLED(time -> time.concat(" 시간의 예약이 취소 되었습니다")),
+    RESERVATION_ONE_HOUR_LEFT(time -> time.concat(" 시간 예약까지 한시간 남았습니다")),
+    RESERVATION_TIME_OUT(time -> "예약 시간이 되었습니다. 입장해주세요.");
 
-    private final String message;
 
+    private final Function<String, String> expression;
+
+    public String apply(String time){
+        return expression.apply(time);
+    }
 
 }

--- a/src/main/java/com/prgrms/catchtable/common/notification/NotificationContent.java
+++ b/src/main/java/com/prgrms/catchtable/common/notification/NotificationContent.java
@@ -15,7 +15,7 @@ public enum NotificationContent {
 
     private final Function<String, String> expression;
 
-    public String apply(String time) {
+    public String getMessage(String time) {
         return expression.apply(time);
     }
 

--- a/src/main/java/com/prgrms/catchtable/common/notification/NotificationEvent.java
+++ b/src/main/java/com/prgrms/catchtable/common/notification/NotificationEvent.java
@@ -22,7 +22,7 @@ public class NotificationEvent {
     @TransactionalEventListener(phase = AFTER_COMMIT) // 호출한쪽의 트랜잭션이 커밋 된 후 이벤트 발생
     public void sendMessage(SendMessageToMemberRequest request) {
         Member member = request.member();
-        if(member.isNotification_activated()){
+        if (member.isNotification_activated()) {
             notificationService.sendMessageAndSave(member, request.content());
         }
     }
@@ -31,7 +31,7 @@ public class NotificationEvent {
     @TransactionalEventListener(phase = AFTER_COMMIT) // 호출한쪽의 트랜잭션이 커밋 된 후 이벤트 발생
     public void sendMessage(SendMessageToOwnerRequest request) {
         Owner owner = request.owner();
-        if(owner.isNotification_activated()){
+        if (owner.isNotification_activated()) {
             notificationService.sendMessageAndSave(request.owner(), request.content());
         }
     }

--- a/src/main/java/com/prgrms/catchtable/common/notification/NotificationEvent.java
+++ b/src/main/java/com/prgrms/catchtable/common/notification/NotificationEvent.java
@@ -2,9 +2,11 @@ package com.prgrms.catchtable.common.notification;
 
 import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
 
+import com.prgrms.catchtable.member.domain.Member;
 import com.prgrms.catchtable.notification.dto.request.SendMessageToMemberRequest;
 import com.prgrms.catchtable.notification.dto.request.SendMessageToOwnerRequest;
 import com.prgrms.catchtable.notification.service.NotificationService;
+import com.prgrms.catchtable.owner.domain.Owner;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -19,12 +21,18 @@ public class NotificationEvent {
     @Async
     @TransactionalEventListener(phase = AFTER_COMMIT) // 호출한쪽의 트랜잭션이 커밋 된 후 이벤트 발생
     public void sendMessage(SendMessageToMemberRequest request) {
-        notificationService.sendMessageAndSave(request.member(), request.content());
+        Member member = request.member();
+        if(member.isNotification_activated()){
+            notificationService.sendMessageAndSave(member, request.content());
+        }
     }
 
     @Async
     @TransactionalEventListener(phase = AFTER_COMMIT) // 호출한쪽의 트랜잭션이 커밋 된 후 이벤트 발생
     public void sendMessage(SendMessageToOwnerRequest request) {
-        notificationService.sendMessageAndSave(request.owner(), request.content());
+        Owner owner = request.owner();
+        if(owner.isNotification_activated()){
+            notificationService.sendMessageAndSave(request.owner(), request.content());
+        }
     }
 }

--- a/src/main/java/com/prgrms/catchtable/notification/dto/request/SendMessageToMemberRequest.java
+++ b/src/main/java/com/prgrms/catchtable/notification/dto/request/SendMessageToMemberRequest.java
@@ -6,6 +6,6 @@ import lombok.Builder;
 
 @Builder
 public record SendMessageToMemberRequest(Member member,
-                                         NotificationContent content) {
+                                         String content) {
 
 }

--- a/src/main/java/com/prgrms/catchtable/notification/dto/request/SendMessageToMemberRequest.java
+++ b/src/main/java/com/prgrms/catchtable/notification/dto/request/SendMessageToMemberRequest.java
@@ -1,6 +1,5 @@
 package com.prgrms.catchtable.notification.dto.request;
 
-import com.prgrms.catchtable.common.notification.NotificationContent;
 import com.prgrms.catchtable.member.domain.Member;
 import lombok.Builder;
 

--- a/src/main/java/com/prgrms/catchtable/notification/dto/request/SendMessageToOwnerRequest.java
+++ b/src/main/java/com/prgrms/catchtable/notification/dto/request/SendMessageToOwnerRequest.java
@@ -1,6 +1,5 @@
 package com.prgrms.catchtable.notification.dto.request;
 
-import com.prgrms.catchtable.common.notification.NotificationContent;
 import com.prgrms.catchtable.owner.domain.Owner;
 import lombok.Builder;
 

--- a/src/main/java/com/prgrms/catchtable/notification/dto/request/SendMessageToOwnerRequest.java
+++ b/src/main/java/com/prgrms/catchtable/notification/dto/request/SendMessageToOwnerRequest.java
@@ -6,6 +6,6 @@ import lombok.Builder;
 
 @Builder
 public record SendMessageToOwnerRequest(Owner owner,
-                                        NotificationContent content) {
+                                        String content) {
 
 }

--- a/src/main/java/com/prgrms/catchtable/notification/service/NotificationService.java
+++ b/src/main/java/com/prgrms/catchtable/notification/service/NotificationService.java
@@ -5,7 +5,6 @@ import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.POST;
 
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
-import com.prgrms.catchtable.common.notification.NotificationContent;
 import com.prgrms.catchtable.member.domain.Member;
 import com.prgrms.catchtable.member.repository.MemberRepository;
 import com.prgrms.catchtable.notification.domain.NotificationMember;

--- a/src/main/java/com/prgrms/catchtable/notification/service/NotificationService.java
+++ b/src/main/java/com/prgrms/catchtable/notification/service/NotificationService.java
@@ -38,11 +38,11 @@ public class NotificationService {
     private final OwnerRepository ownerRepository; // 추후 삭제 예정
     private JSONObject jsonObject;
 
-    public void sendMessageAndSave(Member member, NotificationContent content) {
+    public void sendMessageAndSave(Member member, String content) {
         String url = "https://slack.com/api/chat.postMessage"; // slack 메세지를 보내도록 요청하는 Slack API
 
         String email = member.getEmail();
-        String message = content.getMessage();
+        String message = content;
         String slackId = getSlackIdByEmail(email); // 이메일을 통해 사용자의 슬랙 고유 ID 추출
 
         requestToSendMessage(slackId, message); // 알림 요청 보내는 함수 호출
@@ -56,11 +56,11 @@ public class NotificationService {
 
     }
 
-    public void sendMessageAndSave(Owner owner, NotificationContent content) {
+    public void sendMessageAndSave(Owner owner, String content) {
         String url = "https://slack.com/api/chat.postMessage"; // slack 메세지를 보내도록 요청하는 Slack API
 
         String email = owner.getEmail();
-        String message = content.getMessage();
+        String message = content;
         String slackId = getSlackIdByEmail(email);
 
         requestToSendMessage(slackId, message);

--- a/src/main/java/com/prgrms/catchtable/owner/domain/Owner.java
+++ b/src/main/java/com/prgrms/catchtable/owner/domain/Owner.java
@@ -61,6 +61,9 @@ public class Owner extends BaseEntity implements UserDetails {
     @Column(name = "date_birth")
     private LocalDate dateBirth;
 
+    @Column(name = "notification_activated")
+    private boolean notification_activated;
+
     @OneToOne(fetch = LAZY)
     @JoinColumn(name = "shop_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Shop shop;
@@ -75,6 +78,7 @@ public class Owner extends BaseEntity implements UserDetails {
         this.gender = gender;
         this.dateBirth = dateBirth;
         this.role = Role.OWNER;
+        this.notification_activated = true;
     }
 
     @Override

--- a/src/main/java/com/prgrms/catchtable/owner/repository/OwnerRepository.java
+++ b/src/main/java/com/prgrms/catchtable/owner/repository/OwnerRepository.java
@@ -1,6 +1,7 @@
 package com.prgrms.catchtable.owner.repository;
 
 import com.prgrms.catchtable.owner.domain.Owner;
+import com.prgrms.catchtable.shop.domain.Shop;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,5 +10,7 @@ public interface OwnerRepository extends JpaRepository<Owner, Long> {
     boolean existsOwnerByEmail(String email);
 
     Optional<Owner> findOwnerByEmail(String email);
+
+    Optional<Owner> findOwnerByShop(Shop shop);
 
 }

--- a/src/main/java/com/prgrms/catchtable/reservation/controller/MemberReservationController.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/controller/MemberReservationController.java
@@ -52,8 +52,9 @@ public class MemberReservationController {
 
     @DeleteMapping("/{reservationId}")
     public ResponseEntity<CancelReservationResponse> cancelReservation(
+        @LogIn Member member,
         @PathVariable("reservationId") Long reservationId) {
-        return ResponseEntity.ok(memberReservationService.cancelReservation(reservationId));
+        return ResponseEntity.ok(memberReservationService.cancelReservation(member, reservationId));
     }
 
     @GetMapping

--- a/src/main/java/com/prgrms/catchtable/reservation/service/MemberReservationService.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/service/MemberReservationService.java
@@ -4,6 +4,7 @@ import static com.prgrms.catchtable.common.exception.ErrorCode.ALREADY_OCCUPIED_
 import static com.prgrms.catchtable.common.exception.ErrorCode.ALREADY_PREOCCUPIED_RESERVATION_TIME;
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_RESERVATION;
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_TIME;
+import static com.prgrms.catchtable.common.notification.NotificationContent.*;
 import static com.prgrms.catchtable.reservation.domain.ReservationStatus.CANCELLED;
 import static com.prgrms.catchtable.reservation.domain.ReservationStatus.COMPLETED;
 import static com.prgrms.catchtable.reservation.dto.mapper.ReservationMapper.toCancelReservationResponse;
@@ -13,7 +14,9 @@ import static java.lang.Boolean.FALSE;
 
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
+import com.prgrms.catchtable.common.notification.NotificationContent;
 import com.prgrms.catchtable.member.domain.Member;
+import com.prgrms.catchtable.notification.dto.request.SendMessageToMemberRequest;
 import com.prgrms.catchtable.reservation.domain.Reservation;
 import com.prgrms.catchtable.reservation.domain.ReservationTime;
 import com.prgrms.catchtable.reservation.dto.mapper.ReservationMapper;
@@ -29,6 +32,7 @@ import com.prgrms.catchtable.reservation.repository.ReservationTimeRepository;
 import com.prgrms.catchtable.shop.domain.Shop;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,6 +44,7 @@ public class MemberReservationService {
     private final ReservationRepository reservationRepository;
     private final ReservationAsync reservationAsync;
     private final ReservationLockRepository reservationLockRepository;
+    private final ApplicationEventPublisher publisher;
 
     @Transactional
     public CreateReservationResponse preOccupyReservation(Member member,
@@ -91,6 +96,13 @@ public class MemberReservationService {
             .member(member)
             .build();
         Reservation savedReservation = reservationRepository.save(reservation);
+
+        SendMessageToMemberRequest sendMessage = new SendMessageToMemberRequest(
+            member,
+            RESERVATION_COMPLETED
+        );
+
+        publisher.publishEvent(sendMessage);
         return toCreateReservationResponse(savedReservation);
     }
 

--- a/src/main/java/com/prgrms/catchtable/reservation/service/MemberReservationService.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/service/MemberReservationService.java
@@ -63,7 +63,8 @@ public class MemberReservationService {
                 Thread.currentThread().interrupt();
             }
         }
-        ReservationTime reservationTime = reservationTimeRepository.findByIdWithShop(reservationTimeId)
+        ReservationTime reservationTime = reservationTimeRepository.findByIdWithShop(
+                reservationTimeId)
             .orElseThrow(() -> {
                     reservationLockRepository.unlock(reservationTimeId);
                     return new NotFoundCustomException(NOT_EXIST_TIME);
@@ -103,7 +104,8 @@ public class MemberReservationService {
             .build();
         Reservation savedReservation = reservationRepository.save(reservation);
 
-        sendMessageToMemberAndOwner(member, reservationTime, RESERVATION_COMPLETED); //점주와 회원에게 알림 발송
+        sendMessageToMemberAndOwner(member, reservationTime,
+            RESERVATION_COMPLETED); //점주와 회원에게 알림 발송
 
         return toCreateReservationResponse(savedReservation);
     }
@@ -159,7 +161,8 @@ public class MemberReservationService {
         return toCancelReservationResponse(reservation);
     }
 
-    private void sendMessageToMemberAndOwner(Member member, ReservationTime reservationTime, NotificationContent content) {
+    private void sendMessageToMemberAndOwner(Member member, ReservationTime reservationTime,
+        NotificationContent content) {
 
         Owner owner = ownerRepository.findOwnerByShop(reservationTime.getShop())
             .orElseThrow(() -> new NotFoundCustomException(NOT_EXIST_OWNER));

--- a/src/main/java/com/prgrms/catchtable/reservation/service/MemberReservationService.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/service/MemberReservationService.java
@@ -2,9 +2,11 @@ package com.prgrms.catchtable.reservation.service;
 
 import static com.prgrms.catchtable.common.exception.ErrorCode.ALREADY_OCCUPIED_RESERVATION_TIME;
 import static com.prgrms.catchtable.common.exception.ErrorCode.ALREADY_PREOCCUPIED_RESERVATION_TIME;
+import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_OWNER;
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_RESERVATION;
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_TIME;
-import static com.prgrms.catchtable.common.notification.NotificationContent.*;
+import static com.prgrms.catchtable.common.notification.NotificationContent.RESERVATION_CANCELLED;
+import static com.prgrms.catchtable.common.notification.NotificationContent.RESERVATION_COMPLETED;
 import static com.prgrms.catchtable.reservation.domain.ReservationStatus.CANCELLED;
 import static com.prgrms.catchtable.reservation.domain.ReservationStatus.COMPLETED;
 import static com.prgrms.catchtable.reservation.dto.mapper.ReservationMapper.toCancelReservationResponse;
@@ -14,9 +16,11 @@ import static java.lang.Boolean.FALSE;
 
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
-import com.prgrms.catchtable.common.notification.NotificationContent;
 import com.prgrms.catchtable.member.domain.Member;
 import com.prgrms.catchtable.notification.dto.request.SendMessageToMemberRequest;
+import com.prgrms.catchtable.notification.dto.request.SendMessageToOwnerRequest;
+import com.prgrms.catchtable.owner.domain.Owner;
+import com.prgrms.catchtable.owner.repository.OwnerRepository;
 import com.prgrms.catchtable.reservation.domain.Reservation;
 import com.prgrms.catchtable.reservation.domain.ReservationTime;
 import com.prgrms.catchtable.reservation.dto.mapper.ReservationMapper;
@@ -44,6 +48,7 @@ public class MemberReservationService {
     private final ReservationRepository reservationRepository;
     private final ReservationAsync reservationAsync;
     private final ReservationLockRepository reservationLockRepository;
+    private final OwnerRepository ownerRepository;
     private final ApplicationEventPublisher publisher;
 
     @Transactional
@@ -97,12 +102,22 @@ public class MemberReservationService {
             .build();
         Reservation savedReservation = reservationRepository.save(reservation);
 
-        SendMessageToMemberRequest sendMessage = new SendMessageToMemberRequest(
-            member,
-            RESERVATION_COMPLETED
-        );
+        Owner owner = ownerRepository.findOwnerByShop(reservationTime.getShop())
+            .orElseThrow(() -> new NotFoundCustomException(NOT_EXIST_OWNER));
 
-        publisher.publishEvent(sendMessage);
+        SendMessageToMemberRequest sendMessageToMember = new SendMessageToMemberRequest(
+            member,
+            RESERVATION_COMPLETED.apply(reservationTime.getTime().toString())
+        ); // 회원에게 보낼 해당 시간대의 예약 완료 알림 생성
+
+        SendMessageToOwnerRequest sendMessageToOwner = new SendMessageToOwnerRequest(
+            owner,
+            RESERVATION_COMPLETED.apply(reservationTime.getTime().toString())
+        ); // 점주에게 보낼 보낼 해당 시간대의 예약 완료 알림 생성
+
+        publisher.publishEvent(sendMessageToMember); // 회원에게 예약등록 알림 발송
+        publisher.publishEvent(sendMessageToOwner); // 점주에게 예약등록 알림 발송
+
         return toCreateReservationResponse(savedReservation);
     }
 
@@ -151,6 +166,14 @@ public class MemberReservationService {
         ReservationTime reservationTime = reservation.getReservationTime(); // 해당 예약의 예약시간 차지 여부 true로 변경
 
         reservationTime.setOccupiedFalse();
+
+        Owner owner = ownerRepository.findOwnerByShop(reservationTime.getShop())
+            .orElseThrow(() -> new NotFoundCustomException(NOT_EXIST_OWNER));
+
+        SendMessageToOwnerRequest sendMessageToOwner = new SendMessageToOwnerRequest(owner,
+            RESERVATION_CANCELLED.apply(reservationTime.getTime().toString())); // 해당 시간의 예약 취소 메세지 dto 생성
+
+        publisher.publishEvent(sendMessageToOwner); // 취소한 예약의 매장 점주에게 예약 취소 알림 발송
 
         return toCancelReservationResponse(reservation);
     }

--- a/src/main/java/com/prgrms/catchtable/reservation/service/MemberReservationService.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/service/MemberReservationService.java
@@ -169,11 +169,11 @@ public class MemberReservationService {
 
         SendMessageToMemberRequest sendMessageToMember = new SendMessageToMemberRequest(
             member,
-            content.apply(reservationTime.getTime().toString())
+            content.getMessage(reservationTime.getTime().toString())
         ); // 회원에게 보낼 해당 시간대의 예약 완료 알림 생성
 
         SendMessageToOwnerRequest sendMessageToOwner = new SendMessageToOwnerRequest(owner,
-            content.apply(
+            content.getMessage(
                 reservationTime.getTime().toString())); // 해당 시간의 예약 취소 메세지 dto 생성
 
         publisher.publishEvent(sendMessageToMember);

--- a/src/main/java/com/prgrms/catchtable/reservation/service/MemberReservationService.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/service/MemberReservationService.java
@@ -62,7 +62,7 @@ public class MemberReservationService {
                 Thread.currentThread().interrupt();
             }
         }
-        ReservationTime reservationTime = reservationTimeRepository.findById(reservationTimeId)
+        ReservationTime reservationTime = reservationTimeRepository.findByIdWithShop(reservationTimeId)
             .orElseThrow(() -> {
                     reservationLockRepository.unlock(reservationTimeId);
                     return new NotFoundCustomException(NOT_EXIST_TIME);

--- a/src/main/java/com/prgrms/catchtable/reservation/service/MemberReservationService.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/service/MemberReservationService.java
@@ -171,7 +171,8 @@ public class MemberReservationService {
             .orElseThrow(() -> new NotFoundCustomException(NOT_EXIST_OWNER));
 
         SendMessageToOwnerRequest sendMessageToOwner = new SendMessageToOwnerRequest(owner,
-            RESERVATION_CANCELLED.apply(reservationTime.getTime().toString())); // 해당 시간의 예약 취소 메세지 dto 생성
+            RESERVATION_CANCELLED.apply(
+                reservationTime.getTime().toString())); // 해당 시간의 예약 취소 메세지 dto 생성
 
         publisher.publishEvent(sendMessageToOwner); // 취소한 예약의 매장 점주에게 예약 취소 알림 발송
 

--- a/src/test/java/com/prgrms/catchtable/owner/repository/OwnerRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/owner/repository/OwnerRepositoryTest.java
@@ -17,6 +17,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = NONE)
 class OwnerRepositoryTest {
+
     @Autowired
     private OwnerRepository ownerRepository;
     @Autowired
@@ -24,7 +25,7 @@ class OwnerRepositoryTest {
 
     @Test
     @DisplayName("매장을 통해 점주를 찾을 수 있다")
-    void findByShop(){
+    void findByShop() {
         Shop shop = ShopFixture.shop();
         Shop savedShop = shopRepository.save(shop);
 

--- a/src/test/java/com/prgrms/catchtable/owner/repository/OwnerRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/owner/repository/OwnerRepositoryTest.java
@@ -1,0 +1,38 @@
+package com.prgrms.catchtable.owner.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.NONE;
+
+import com.prgrms.catchtable.owner.domain.Owner;
+import com.prgrms.catchtable.owner.fixture.OwnerFixture;
+import com.prgrms.catchtable.shop.domain.Shop;
+import com.prgrms.catchtable.shop.fixture.ShopFixture;
+import com.prgrms.catchtable.shop.repository.ShopRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = NONE)
+class OwnerRepositoryTest {
+    @Autowired
+    private OwnerRepository ownerRepository;
+    @Autowired
+    private ShopRepository shopRepository;
+
+    @Test
+    @DisplayName("매장을 통해 점주를 찾을 수 있다")
+    void findByShop(){
+        Shop shop = ShopFixture.shop();
+        Shop savedShop = shopRepository.save(shop);
+
+        Owner owner = OwnerFixture.getOwner(savedShop);
+        Owner savedOwner = ownerRepository.save(owner);
+
+        Owner findOwner = ownerRepository.findOwnerByShop(savedShop).orElseThrow();
+
+        assertThat(findOwner).isEqualTo(savedOwner);
+    }
+}

--- a/src/test/java/com/prgrms/catchtable/owner/repository/OwnerRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/owner/repository/OwnerRepositoryTest.java
@@ -29,7 +29,8 @@ class OwnerRepositoryTest {
         Shop shop = ShopFixture.shop();
         Shop savedShop = shopRepository.save(shop);
 
-        Owner owner = OwnerFixture.getOwner(savedShop);
+        Owner owner = OwnerFixture.getOwner("injun", "injun2480");
+        owner.insertShop(savedShop);
         Owner savedOwner = ownerRepository.save(owner);
 
         Owner findOwner = ownerRepository.findOwnerByShop(savedShop).orElseThrow();

--- a/src/test/java/com/prgrms/catchtable/reservation/controller/MemberReservationControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/controller/MemberReservationControllerTest.java
@@ -207,6 +207,7 @@ class MemberReservationControllerTest extends BaseIntegrationTest {
         Reservation savedReservation = reservationRepository.save(reservation);
 
         mockMvc.perform(delete("/reservations/{reservationId}", savedReservation.getId())
+                .headers(httpHeaders)
                 .contentType(APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.status").value(CANCELLED.toString()));

--- a/src/test/java/com/prgrms/catchtable/reservation/controller/MemberReservationControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/controller/MemberReservationControllerTest.java
@@ -54,7 +54,6 @@ class MemberReservationControllerTest extends BaseIntegrationTest {
         Shop shop = ShopData.getShop();
         Shop savedShop = shopRepository.save(shop);
 
-
         Member savedMember = memberRepository.save(member);
 
         ReservationTime reservationTime = ReservationFixture.getReservationTimeNotPreOccupied();

--- a/src/test/java/com/prgrms/catchtable/reservation/controller/MemberReservationControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/controller/MemberReservationControllerTest.java
@@ -76,7 +76,7 @@ class MemberReservationControllerTest extends BaseIntegrationTest {
     }
 
     @AfterEach
-    void tearDown(){
+    void tearDown() {
         shopRepository.deleteAll();
     }
 

--- a/src/test/java/com/prgrms/catchtable/reservation/controller/MemberReservationControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/controller/MemberReservationControllerTest.java
@@ -18,6 +18,9 @@ import com.prgrms.catchtable.jwt.token.Token;
 import com.prgrms.catchtable.member.MemberFixture;
 import com.prgrms.catchtable.member.domain.Member;
 import com.prgrms.catchtable.member.repository.MemberRepository;
+import com.prgrms.catchtable.owner.domain.Owner;
+import com.prgrms.catchtable.owner.fixture.OwnerFixture;
+import com.prgrms.catchtable.owner.repository.OwnerRepository;
 import com.prgrms.catchtable.reservation.domain.Reservation;
 import com.prgrms.catchtable.reservation.domain.ReservationTime;
 import com.prgrms.catchtable.reservation.dto.request.CreateReservationRequest;
@@ -28,6 +31,7 @@ import com.prgrms.catchtable.reservation.repository.ReservationTimeRepository;
 import com.prgrms.catchtable.shop.domain.Shop;
 import com.prgrms.catchtable.shop.repository.ShopRepository;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
@@ -47,12 +51,18 @@ class MemberReservationControllerTest extends BaseIntegrationTest {
     private ReservationRepository reservationRepository;
     @Autowired
     private MemberRepository memberRepository;
+    @Autowired
+    private OwnerRepository ownerRepository;
     private Member member = MemberFixture.member("dlswns661035@gmail.com");
 
     @BeforeEach
     void setUp() {
         Shop shop = ShopData.getShop();
         Shop savedShop = shopRepository.save(shop);
+
+        Owner owner = OwnerFixture.getOwner("injun", "injun2480");
+        owner.insertShop(savedShop);
+        ownerRepository.save(owner);
 
         Member savedMember = memberRepository.save(member);
 
@@ -63,6 +73,11 @@ class MemberReservationControllerTest extends BaseIntegrationTest {
         Token token = jwtTokenProvider.createToken(savedMember.getEmail(), MEMBER);
         httpHeaders.add("AccessToken", token.getAccessToken());
         httpHeaders.add("RefreshToken", token.getRefreshToken());
+    }
+
+    @AfterEach
+    void tearDown(){
+        shopRepository.deleteAll();
     }
 
     @Test

--- a/src/test/java/com/prgrms/catchtable/reservation/service/MemberReservationServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/service/MemberReservationServiceTest.java
@@ -71,7 +71,8 @@ class MemberReservationServiceTest {
         CreateReservationRequest request = ReservationFixture.getCreateReservationRequestWithId(
             reservationTime.getId());
 
-        when(reservationTimeRepository.findByIdWithShop(1L)).thenReturn(Optional.of(reservationTime));
+        when(reservationTimeRepository.findByIdWithShop(1L)).thenReturn(
+            Optional.of(reservationTime));
         when(reservationLockRepository.lock(1L)).thenReturn(TRUE);
         when(reservationLockRepository.unlock(1L)).thenReturn(TRUE);
         doNothing().when(reservationAsync).setPreOcuppied(reservationTime);
@@ -99,7 +100,8 @@ class MemberReservationServiceTest {
         CreateReservationRequest request = ReservationFixture.getCreateReservationRequestWithId(
             reservationTime.getId());
 
-        when(reservationTimeRepository.findByIdWithShop(1L)).thenReturn(Optional.of(reservationTime));
+        when(reservationTimeRepository.findByIdWithShop(1L)).thenReturn(
+            Optional.of(reservationTime));
         when(reservationLockRepository.lock(1L)).thenReturn(TRUE);
 
         //when

--- a/src/test/java/com/prgrms/catchtable/reservation/service/MemberReservationServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/service/MemberReservationServiceTest.java
@@ -272,6 +272,7 @@ class MemberReservationServiceTest {
     @DisplayName("예약을 취소할 수 있다")
     void cancelReservation() {
         //given
+        Member member = MemberFixture.member("dlswns661035@gmail.com");
         ReservationTime reservationTime = ReservationFixture.getReservationTimeOccupied();
         ModifyReservationRequest request = ReservationFixture.getModifyReservationRequest(1L);
         Reservation reservation = ReservationFixture.getReservation(reservationTime);
@@ -283,6 +284,7 @@ class MemberReservationServiceTest {
         when(ownerRepository.findOwnerByShop(any(Shop.class))).thenReturn(Optional.of(owner));
         //when
         CancelReservationResponse response = memberReservationService.cancelReservation(
+            member,
             reservation.getId());
 
         //then
@@ -297,11 +299,12 @@ class MemberReservationServiceTest {
     @Test
     @DisplayName("존재하지 않는 예약에 대한 삭제 요청 시 예외가 발생한다")
     void cancelReservationNotExist() {
+        Member member = MemberFixture.member("asd@gmail.com");
         when(reservationRepository.findByIdWithReservationTimeAndShop(1L)).thenReturn(
             Optional.empty());
 
         assertThrows(NotFoundCustomException.class,
-            () -> memberReservationService.cancelReservation(1L));
+            () -> memberReservationService.cancelReservation(member, 1L));
     }
 
 }


### PR DESCRIPTION
- close #79 
### ⛏ 작업 상세 내용

- NotificationContent
    - 기존 :  알림 이벤트 발행 시 enum 클래스 자체를 넘겨서 알림 서비스에서 메세지 추출해 메세지 발송
    - 변경 : 특정 시간의 예약에 대한 알림을 보내기 위해 enum 에 시간을 인자로 받아서 메세지 생성(자바의 Function 인터페이스 활용)
    - 이에 따른 NotificationService와 메세지보내는 Dto 인자 수정
- OwnerRepository
    - 매장을 통해 점주 조회하는 쿼리 추가 (고객이 예약 등록, 취소 시 점주에게 알림 보내기 위함)
- MemberReservationService
    - 예약 등록 시 회원과 점주에게 해당시간대의 예약 등록 알림 발송, 예약 취소 시 점주에게 해당 시간대의 예약 취소 알림 발송  

### 📝 작업 요약

- 예약기능 알림 로직 추가

### **☑️** 중점적으로 리뷰 할 부분

- enum 활용부분
- 알림 로직 추가한 부분
