### PR TITLE
feat : 예약 api REST Docs 명세

### DIFF
--- a/src/main/java/com/prgrms/catchtable/reservation/controller/OwnerReservationController.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/controller/OwnerReservationController.java
@@ -11,7 +11,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;

--- a/src/main/java/com/prgrms/catchtable/reservation/controller/OwnerReservationController.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/controller/OwnerReservationController.java
@@ -1,5 +1,7 @@
 package com.prgrms.catchtable.reservation.controller;
 
+import com.prgrms.catchtable.common.login.LogIn;
+import com.prgrms.catchtable.owner.domain.Owner;
 import com.prgrms.catchtable.reservation.dto.request.ModifyReservationStatusRequest;
 import com.prgrms.catchtable.reservation.dto.response.OwnerGetAllReservationResponse;
 import com.prgrms.catchtable.reservation.service.OwnerReservationService;
@@ -7,6 +9,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,7 +23,7 @@ public class OwnerReservationController {
 
     private final OwnerReservationService ownerReservationService;
 
-    @PostMapping("/{reservationId}")
+    @PatchMapping("/{reservationId}")
     public void modifyReservationStatus(
         @PathVariable("reservationId") Long reservationId,
         @RequestBody ModifyReservationStatusRequest request
@@ -30,7 +33,7 @@ public class OwnerReservationController {
 
     @GetMapping
     public ResponseEntity<List<OwnerGetAllReservationResponse>> getAllReservation(
-        @RequestBody Long ownerId) {
-        return ResponseEntity.ok(ownerReservationService.getAllReservation(ownerId));
+        @LogIn Owner owner) {
+        return ResponseEntity.ok(ownerReservationService.getAllReservation(owner));
     }
 }

--- a/src/main/java/com/prgrms/catchtable/reservation/service/OwnerReservationService.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/service/OwnerReservationService.java
@@ -59,8 +59,8 @@ public class OwnerReservationService {
      * @return
      */
     @Transactional(readOnly = true)
-    public List<OwnerGetAllReservationResponse> getAllReservation(Long ownerId) {
-        Owner owner = ownerRepository.findById(ownerId).orElseThrow();
+    public List<OwnerGetAllReservationResponse> getAllReservation(Owner owner) {
+
         List<Reservation> reservations = reservationRepository.findAllWithReservationTimeAndShopByShopId(
             owner.getShop().getId());
 

--- a/src/test/java/com/prgrms/catchtable/common/restdocs/RestDocsSupport.java
+++ b/src/test/java/com/prgrms/catchtable/common/restdocs/RestDocsSupport.java
@@ -1,11 +1,13 @@
 package com.prgrms.catchtable.common.restdocs;
 
 import static com.prgrms.catchtable.common.Role.MEMBER;
+import static com.prgrms.catchtable.common.Role.OWNER;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.prgrms.catchtable.jwt.provider.JwtTokenProvider;
 import com.prgrms.catchtable.jwt.token.Token;
 import com.prgrms.catchtable.member.domain.Member;
+import com.prgrms.catchtable.owner.domain.Owner;
 import jakarta.servlet.ServletException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -64,6 +66,13 @@ public abstract class RestDocsSupport {
 
     public HttpHeaders getHttpHeaders(Member member) {
         Token token = jwtTokenProvider.createToken(member.getEmail(), MEMBER);
+        httpHeaders.add("AccessToken", token.getAccessToken());
+        httpHeaders.add("RefreshToken", token.getRefreshToken());
+        return httpHeaders;
+    }
+
+    public HttpHeaders getHttpHeaders(Owner owner) {
+        Token token = jwtTokenProvider.createToken(owner.getEmail(), OWNER);
         httpHeaders.add("AccessToken", token.getAccessToken());
         httpHeaders.add("RefreshToken", token.getRefreshToken());
         return httpHeaders;

--- a/src/test/java/com/prgrms/catchtable/reservation/controller/MemberReservationControllerDocsTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/controller/MemberReservationControllerDocsTest.java
@@ -38,6 +38,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 public class MemberReservationControllerDocsTest extends RestDocsSupport {
+
     @MockBean
     private MemberReservationService memberReservationService;
 
@@ -45,11 +46,10 @@ public class MemberReservationControllerDocsTest extends RestDocsSupport {
     private MemberRepository memberRepository;
 
     @BeforeEach
-    void setUp(){
+    void setUp() {
         Member member = MemberFixture.member("dlswns6asd61035@gmail.com");
         Member savedMember = memberRepository.save(member);
     }
-
 
 
     @Test
@@ -68,28 +68,28 @@ public class MemberReservationControllerDocsTest extends RestDocsSupport {
         when(memberReservationService.preOccupyReservation(member, request)).thenReturn(response);
 
         mockMvc.perform(post("/reservations")
-            .headers(getHttpHeaders(member))
-            .contentType(APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(request)))
+                .headers(getHttpHeaders(member))
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isOk())
             .andDo(restDocs.document(
-                requestFields(
-                    fieldWithPath("reservationTimeId").type(NUMBER)
-                        .description("예약시간 id"),
-                    fieldWithPath("peopleCount").type(NUMBER)
-                        .description("예약 인원")
-                ),
-                responseFields(
-                    fieldWithPath("shopName").type(STRING)
-                        .description("매장명"),
-                    fieldWithPath("memberName").type(STRING)
-                        .description("예약자 이름"),
-                    fieldWithPath("date").type(STRING)
-                        .description("예약 날짜 및 시간"),
-                    fieldWithPath("peopleCount").type(NUMBER)
-                        .description("예약 인원")
+                    requestFields(
+                        fieldWithPath("reservationTimeId").type(NUMBER)
+                            .description("예약시간 id"),
+                        fieldWithPath("peopleCount").type(NUMBER)
+                            .description("예약 인원")
+                    ),
+                    responseFields(
+                        fieldWithPath("shopName").type(STRING)
+                            .description("매장명"),
+                        fieldWithPath("memberName").type(STRING)
+                            .description("예약자 이름"),
+                        fieldWithPath("date").type(STRING)
+                            .description("예약 날짜 및 시간"),
+                        fieldWithPath("peopleCount").type(NUMBER)
+                            .description("예약 인원")
+                    )
                 )
-            )
             );
     }
 
@@ -158,7 +158,7 @@ public class MemberReservationControllerDocsTest extends RestDocsSupport {
         when(memberReservationService.getAllReservation(member)).thenReturn(response);
 
         mockMvc.perform(get("/reservations")
-            .headers(getHttpHeaders(member)))
+                .headers(getHttpHeaders(member)))
             .andExpect(status().isOk())
             .andDo(restDocs.document(
                 responseFields(
@@ -171,7 +171,7 @@ public class MemberReservationControllerDocsTest extends RestDocsSupport {
                     fieldWithPath("[0].peopleCount").type(NUMBER)
                         .description("예약 인원 수"),
                     fieldWithPath("[0].status").type(STRING)
-                            .description("예약 상태"),
+                        .description("예약 상태"),
                     fieldWithPath("[1].reservationId").type(NUMBER)
                         .description("예약 id"),
                     fieldWithPath("[1].date").type(STRING)
@@ -203,9 +203,9 @@ public class MemberReservationControllerDocsTest extends RestDocsSupport {
         when(memberReservationService.modifyReservation(1L, request)).thenReturn(response);
 
         mockMvc.perform(patch("/reservations/{reservationId}", 1)
-            .contentType(APPLICATION_JSON)
-            .headers(getHttpHeaders(member))
-            .content(objectMapper.writeValueAsString(request)))
+                .contentType(APPLICATION_JSON)
+                .headers(getHttpHeaders(member))
+                .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isOk())
             .andDo(restDocs.document(
                 requestFields(
@@ -239,8 +239,8 @@ public class MemberReservationControllerDocsTest extends RestDocsSupport {
         when(memberReservationService.cancelReservation(member, 1L)).thenReturn(response);
 
         mockMvc.perform(delete("/reservations/{reservationId}", 1L)
-            .contentType(APPLICATION_JSON)
-            .headers(getHttpHeaders(member)))
+                .contentType(APPLICATION_JSON)
+                .headers(getHttpHeaders(member)))
             .andExpect(status().isOk())
             .andDo(restDocs.document(
                 responseFields(

--- a/src/test/java/com/prgrms/catchtable/reservation/controller/MemberReservationControllerDocsTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/controller/MemberReservationControllerDocsTest.java
@@ -1,0 +1,253 @@
+package com.prgrms.catchtable.reservation.controller;
+
+import static com.prgrms.catchtable.reservation.domain.ReservationStatus.CANCELLED;
+import static com.prgrms.catchtable.reservation.domain.ReservationStatus.COMPLETED;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.prgrms.catchtable.common.restdocs.RestDocsSupport;
+import com.prgrms.catchtable.member.MemberFixture;
+import com.prgrms.catchtable.member.domain.Member;
+import com.prgrms.catchtable.member.repository.MemberRepository;
+import com.prgrms.catchtable.reservation.dto.request.CreateReservationRequest;
+import com.prgrms.catchtable.reservation.dto.request.ModifyReservationRequest;
+import com.prgrms.catchtable.reservation.dto.response.CancelReservationResponse;
+import com.prgrms.catchtable.reservation.dto.response.CreateReservationResponse;
+import com.prgrms.catchtable.reservation.dto.response.GetAllReservationResponse;
+import com.prgrms.catchtable.reservation.dto.response.ModifyReservationResponse;
+import com.prgrms.catchtable.reservation.fixture.ReservationFixture;
+import com.prgrms.catchtable.reservation.service.MemberReservationService;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+public class MemberReservationControllerDocsTest extends RestDocsSupport {
+    @MockBean
+    private MemberReservationService memberReservationService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp(){
+        Member member = MemberFixture.member("dlswns6asd61035@gmail.com");
+        Member savedMember = memberRepository.save(member);
+    }
+
+
+
+    @Test
+    @DisplayName("예약 선점 api")
+    void preOccupy() throws Exception {
+        Member member = memberRepository.findAll().get(0);
+
+        CreateReservationRequest request = ReservationFixture.getCreateReservationRequest();
+        CreateReservationResponse response = CreateReservationResponse.builder()
+            .shopName("shopA")
+            .memberName(member.getName())
+            .date(LocalDateTime.of(2024, 1, 1, 19, 30))
+            .peopleCount(request.peopleCount())
+            .build();
+
+        when(memberReservationService.preOccupyReservation(member, request)).thenReturn(response);
+
+        mockMvc.perform(post("/reservations")
+            .headers(getHttpHeaders(member))
+            .contentType(APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andDo(restDocs.document(
+                requestFields(
+                    fieldWithPath("reservationTimeId").type(NUMBER)
+                        .description("예약시간 id"),
+                    fieldWithPath("peopleCount").type(NUMBER)
+                        .description("예약 인원")
+                ),
+                responseFields(
+                    fieldWithPath("shopName").type(STRING)
+                        .description("매장명"),
+                    fieldWithPath("memberName").type(STRING)
+                        .description("예약자 이름"),
+                    fieldWithPath("date").type(STRING)
+                        .description("예약 날짜 및 시간"),
+                    fieldWithPath("peopleCount").type(NUMBER)
+                        .description("예약 인원")
+                )
+            )
+            );
+    }
+
+    @Test
+    @DisplayName("예약 등록 api")
+    void register() throws Exception {
+        Member member = memberRepository.findAll().get(0);
+
+        CreateReservationRequest request = ReservationFixture.getCreateReservationRequest();
+        CreateReservationResponse response = CreateReservationResponse.builder()
+            .shopName("shopA")
+            .memberName(member.getName())
+            .date(LocalDateTime.of(2024, 1, 1, 19, 30))
+            .peopleCount(request.peopleCount())
+            .build();
+
+        when(memberReservationService.registerReservation(member, request)).thenReturn(response);
+
+        mockMvc.perform(post("/reservations/success")
+                .headers(getHttpHeaders(member))
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andDo(restDocs.document(
+                    requestFields(
+                        fieldWithPath("reservationTimeId").type(NUMBER)
+                            .description("예약시간 id"),
+                        fieldWithPath("peopleCount").type(NUMBER)
+                            .description("예약 인원")
+                    ),
+                    responseFields(
+                        fieldWithPath("shopName").type(STRING)
+                            .description("매장명"),
+                        fieldWithPath("memberName").type(STRING)
+                            .description("예약자 이름"),
+                        fieldWithPath("date").type(STRING)
+                            .description("예약 날짜 및 시간"),
+                        fieldWithPath("peopleCount").type(NUMBER)
+                            .description("예약 인원")
+                    )
+                )
+            );
+    }
+
+    @Test
+    @DisplayName("예약 전체 조회 api")
+    void getAll() throws Exception {
+        Member member = memberRepository.findAll().get(0);
+        GetAllReservationResponse reservation1 = GetAllReservationResponse.builder()
+            .reservationId(1L)
+            .date(LocalDateTime.of(2024, 1, 1, 19, 30))
+            .shopName("shopA")
+            .peopleCount(5)
+            .status(COMPLETED)
+            .build();
+        GetAllReservationResponse reservation2 = GetAllReservationResponse.builder()
+            .reservationId(2L)
+            .date(LocalDateTime.of(2024, 1, 5, 20, 30))
+            .shopName("shopB")
+            .peopleCount(3)
+            .status(CANCELLED)
+            .build();
+
+        List<GetAllReservationResponse> response = List.of(reservation1, reservation2);
+
+        when(memberReservationService.getAllReservation(member)).thenReturn(response);
+
+        mockMvc.perform(get("/reservations")
+            .headers(getHttpHeaders(member)))
+            .andExpect(status().isOk())
+            .andDo(restDocs.document(
+                responseFields(
+                    fieldWithPath("[0].reservationId").type(NUMBER)
+                        .description("예약 id"),
+                    fieldWithPath("[0].date").type(STRING)
+                        .description("예약 날짜 및 시간"),
+                    fieldWithPath("[0].shopName").type(STRING)
+                        .description("매장명"),
+                    fieldWithPath("[0].peopleCount").type(NUMBER)
+                        .description("예약 인원 수"),
+                    fieldWithPath("[0].status").type(STRING)
+                            .description("예약 상태"),
+                    fieldWithPath("[1].reservationId").type(NUMBER)
+                        .description("예약 id"),
+                    fieldWithPath("[1].date").type(STRING)
+                        .description("예약 날짜 및 시간"),
+                    fieldWithPath("[1].shopName").type(STRING)
+                        .description("매장명"),
+                    fieldWithPath("[1].peopleCount").type(NUMBER)
+                        .description("예약 인원 수"),
+                    fieldWithPath("[1].status").type(STRING)
+                        .description("예약 상태")
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("예약 수정 api")
+    void modify() throws Exception {
+        Member member = memberRepository.findAll().get(0);
+
+        ModifyReservationRequest request = ReservationFixture.getModifyReservationRequest(1L);
+
+        ModifyReservationResponse response = ModifyReservationResponse.builder()
+            .shopName("shopA")
+            .memberName(member.getName())
+            .date(LocalDateTime.of(2024, 1, 1, 19, 30))
+            .peopleCount(5)
+            .build();
+
+        when(memberReservationService.modifyReservation(1L, request)).thenReturn(response);
+
+        mockMvc.perform(patch("/reservations/{reservationId}", 1)
+            .contentType(APPLICATION_JSON)
+            .headers(getHttpHeaders(member))
+            .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andDo(restDocs.document(
+                requestFields(
+                    fieldWithPath("reservationTimeId").type(NUMBER)
+                        .description("수정하려는 예약시간 id"),
+                    fieldWithPath("peopleCount").type(NUMBER)
+                        .description("수정하려는 인원 수")
+                ),
+                responseFields(
+                    fieldWithPath("shopName").type(STRING)
+                        .description("매장명"),
+                    fieldWithPath("memberName").type(STRING)
+                        .description("예약자명"),
+                    fieldWithPath("date").type(STRING)
+                        .description("수정된 예약 날짜 및 시간"),
+                    fieldWithPath("peopleCount").type(NUMBER)
+                        .description("수정된 예약 인원 수")
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("예약 취소 api")
+    void cancel() throws Exception {
+        Member member = memberRepository.findAll().get(0);
+
+        CancelReservationResponse response = CancelReservationResponse.builder()
+            .status(CANCELLED)
+            .build();
+
+        when(memberReservationService.cancelReservation(member, 1L)).thenReturn(response);
+
+        mockMvc.perform(delete("/reservations/{reservationId}", 1L)
+            .contentType(APPLICATION_JSON)
+            .headers(getHttpHeaders(member)))
+            .andExpect(status().isOk())
+            .andDo(restDocs.document(
+                responseFields(
+                    fieldWithPath("status").type(STRING)
+                        .description("예약 상태")
+                )
+            ));
+    }
+
+}

--- a/src/test/java/com/prgrms/catchtable/reservation/controller/OwnerReservationControllerDocsTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/controller/OwnerReservationControllerDocsTest.java
@@ -1,0 +1,113 @@
+package com.prgrms.catchtable.reservation.controller;
+
+import static com.prgrms.catchtable.reservation.domain.ReservationStatus.CANCELLED;
+import static com.prgrms.catchtable.reservation.domain.ReservationStatus.COMPLETED;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.prgrms.catchtable.common.restdocs.RestDocsSupport;
+import com.prgrms.catchtable.owner.domain.Owner;
+import com.prgrms.catchtable.owner.fixture.OwnerFixture;
+import com.prgrms.catchtable.owner.repository.OwnerRepository;
+import com.prgrms.catchtable.reservation.dto.request.ModifyReservationStatusRequest;
+import com.prgrms.catchtable.reservation.dto.response.OwnerGetAllReservationResponse;
+import com.prgrms.catchtable.reservation.fixture.ReservationFixture;
+import com.prgrms.catchtable.reservation.service.OwnerReservationService;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+public class OwnerReservationControllerDocsTest extends RestDocsSupport {
+    @MockBean
+    private OwnerReservationService ownerReservationService;
+    @Autowired
+    private OwnerRepository ownerRepository;
+
+    @BeforeEach
+    void setUp(){
+        Owner owner = OwnerFixture.getOwner("dlswns", "dlswns24802840");
+        ownerRepository.save(owner);
+    }
+
+    @Test
+    @DisplayName("예약 노쇼, 취소 처리 api")
+    void noshowAndCancel() throws Exception {
+        Owner owner = ownerRepository.findAll().get(0);
+
+        ModifyReservationStatusRequest request = ReservationFixture.getModifyReservationStatusRequest(
+            CANCELLED);
+        doNothing().when(ownerReservationService).modifyReservationStatus(1L, request);
+
+        mockMvc.perform(patch("/owners/shop/{reservationId}", 1)
+            .contentType(APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .headers(getHttpHeaders(owner)))
+            .andExpect(status().isOk())
+            .andDo(restDocs.document(
+                requestFields(
+                    fieldWithPath("status").type(STRING)
+                        .description("수정하려는 예약 상태")
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("가게의 예약 전체 조회 api")
+    void getAllReservation() throws Exception {
+        Owner owner = ownerRepository.findAll().get(0);
+        OwnerGetAllReservationResponse reservation1 = OwnerGetAllReservationResponse.builder()
+            .reservationId(1L)
+            .date(LocalDateTime.of(2024, 3, 4, 12, 30))
+            .peopleCount(4)
+            .status(COMPLETED)
+            .build();
+        OwnerGetAllReservationResponse reservation2 = OwnerGetAllReservationResponse.builder()
+            .reservationId(2L)
+            .date(LocalDateTime.of(2024, 3, 25, 17, 30))
+            .peopleCount(2)
+            .status(CANCELLED)
+            .build();
+        List<OwnerGetAllReservationResponse> response = List.of(reservation1, reservation2);
+
+        Mockito.when(ownerReservationService.getAllReservation(owner)).thenReturn(response);
+
+        mockMvc.perform(get("/owners/shop")
+            .headers(getHttpHeaders(owner)))
+            .andExpect(status().isOk())
+            .andDo(restDocs.document(
+                responseFields(
+                    fieldWithPath("[0].reservationId").type(NUMBER)
+                        .description("예약 id"),
+                    fieldWithPath("[0].date").type(STRING)
+                        .description("예약 날짜 및 시간"),
+                    fieldWithPath("[0].peopleCount").type(NUMBER)
+                        .description("예약 인원 수"),
+                    fieldWithPath("[0].status").type(STRING)
+                        .description("예약 상태"),
+                    fieldWithPath("[1].reservationId").type(NUMBER)
+                        .description("예약 id"),
+                    fieldWithPath("[1].date").type(STRING)
+                        .description("예약 날짜 및 시간"),
+                    fieldWithPath("[1].peopleCount").type(NUMBER)
+                        .description("예약 인원 수"),
+                    fieldWithPath("[1].status").type(STRING)
+                        .description("예약 상태")
+                )
+            ));
+    }
+}

--- a/src/test/java/com/prgrms/catchtable/reservation/controller/OwnerReservationControllerDocsTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/controller/OwnerReservationControllerDocsTest.java
@@ -33,13 +33,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 public class OwnerReservationControllerDocsTest extends RestDocsSupport {
+
     @MockBean
     private OwnerReservationService ownerReservationService;
     @Autowired
     private OwnerRepository ownerRepository;
 
     @BeforeEach
-    void setUp(){
+    void setUp() {
         Owner owner = OwnerFixture.getOwner("dlswns", "dlswns24802840");
         ownerRepository.save(owner);
     }
@@ -54,9 +55,9 @@ public class OwnerReservationControllerDocsTest extends RestDocsSupport {
         doNothing().when(ownerReservationService).modifyReservationStatus(1L, request);
 
         mockMvc.perform(patch("/owners/shop/{reservationId}", 1)
-            .contentType(APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(request))
-            .headers(getHttpHeaders(owner)))
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .headers(getHttpHeaders(owner)))
             .andExpect(status().isOk())
             .andDo(restDocs.document(
                 requestFields(
@@ -87,7 +88,7 @@ public class OwnerReservationControllerDocsTest extends RestDocsSupport {
         Mockito.when(ownerReservationService.getAllReservation(owner)).thenReturn(response);
 
         mockMvc.perform(get("/owners/shop")
-            .headers(getHttpHeaders(owner)))
+                .headers(getHttpHeaders(owner)))
             .andExpect(status().isOk())
             .andDo(restDocs.document(
                 responseFields(

--- a/src/test/java/com/prgrms/catchtable/reservation/controller/OwnerReservationControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/controller/OwnerReservationControllerTest.java
@@ -1,13 +1,11 @@
 package com.prgrms.catchtable.reservation.controller;
 
-import static com.prgrms.catchtable.common.Role.MEMBER;
 import static com.prgrms.catchtable.common.Role.OWNER;
 import static com.prgrms.catchtable.reservation.domain.ReservationStatus.CANCELLED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 

--- a/src/test/java/com/prgrms/catchtable/reservation/service/OwnerReservationServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/service/OwnerReservationServiceTest.java
@@ -112,9 +112,8 @@ class OwnerReservationServiceTest {
         Owner owner = OwnerFixture.getOwner("email", "password");
         when(reservationRepository.findAllWithReservationTimeAndShopByShopId(
             any(Long.class))).thenReturn(reservations);
-        when(ownerRepository.findById(any(Long.class))).thenReturn(Optional.of(owner));
         List<OwnerGetAllReservationResponse> allReservation = ownerReservationService.getAllReservation(
-            1L);
+            owner);
 
         assertAll(
             () -> assertThat(allReservation.get(0).date()).isEqualTo(
@@ -131,10 +130,9 @@ class OwnerReservationServiceTest {
 
         when(reservationRepository.findAllWithReservationTimeAndShopByShopId(
             any(Long.class))).thenReturn(List.of());
-        when(ownerRepository.findById(any(Long.class))).thenReturn(Optional.of(owner));
 
         List<OwnerGetAllReservationResponse> allReservation = ownerReservationService.getAllReservation(
-            1L);
+            owner);
 
         assertThat(allReservation).isEmpty();
     }


### PR DESCRIPTION
- close #92 
### ⛏ 작업 상세 내용

- 예약 관련 api 단위 테스트 완료
- 기존에 점주관련 예약에 로그인 어노테이션으로 안 받고 아이디로 받게 돼있어서 전부 수정 및 테스트 코드 수정
- 점주 예약 변경 api 메소드 변경 post -> patch

### 📝 작업 요약

- 예약 api 단위테스트

### **☑️** 중점적으로 리뷰 할 부분

- api 단위 테스트
