### PR TITLE
feat : Rest Docs 명세화

### DIFF
--- a/src/docs/asciidoc/api/waiting/waiting.adoc
+++ b/src/docs/asciidoc/api/waiting/waiting.adoc
@@ -1,5 +1,5 @@
 [[waiting-create]]
-=== 웨이팅 등록
+=== 웨이팅 등록 API
 
 ==== HTTP Request
 
@@ -10,3 +10,59 @@ include::{snippets}/member-waiting-controller-docs-test/create-waiting/request-f
 
 include::{snippets}/member-waiting-controller-docs-test/create-waiting/http-response.adoc[]
 include::{snippets}/member-waiting-controller-docs-test/create-waiting/response-fields.adoc[]
+
+=== 웨이팅 지연 API
+
+==== HTTP Request
+
+include::{snippets}/member-waiting-controller-docs-test/postpone-waiting/http-request.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/member-waiting-controller-docs-test/postpone-waiting/http-response.adoc[]
+include::{snippets}/member-waiting-controller-docs-test/postpone-waiting/response-fields.adoc[]
+
+=== 웨이팅 취소 API
+
+==== HTTP Request
+
+include::{snippets}/member-waiting-controller-docs-test/cancel-waiting/http-request.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/member-waiting-controller-docs-test/cancel-waiting/http-response.adoc[]
+include::{snippets}/member-waiting-controller-docs-test/cancel-waiting/response-fields.adoc[]
+
+=== 회원 진행 중인 웨이팅 조회 API
+
+==== HTTP Request
+
+include::{snippets}/member-waiting-controller-docs-test/get-waiting/http-request.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/member-waiting-controller-docs-test/get-waiting/http-response.adoc[]
+include::{snippets}/member-waiting-controller-docs-test/get-waiting/response-fields.adoc[]
+
+
+=== 웨이팅 입장 API
+
+==== HTTP Request
+
+include::{snippets}/owner-waiting-controller-docs-test/entry-waiting/http-request.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/owner-waiting-controller-docs-test/entry-waiting/http-response.adoc[]
+include::{snippets}/owner-waiting-controller-docs-test/entry-waiting/response-fields.adoc[]
+
+=== 가게 웨이팅 이력 조회 API
+
+==== HTTP Request
+
+include::{snippets}/owner-waiting-controller-docs-test/get-shop-all-waiting/http-request.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/owner-waiting-controller-docs-test/get-shop-all-waiting/http-response.adoc[]
+include::{snippets}/owner-waiting-controller-docs-test/get-shop-all-waiting/response-fields.adoc[]

--- a/src/main/java/com/prgrms/catchtable/waiting/controller/OwnerWaitingController.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/controller/OwnerWaitingController.java
@@ -20,9 +20,9 @@ public class OwnerWaitingController {
     private final OwnerWaitingService ownerWaitingService;
 
     @GetMapping
-    public ResponseEntity<OwnerWaitingListResponse> getOwnerAllWaiting(
+    public ResponseEntity<OwnerWaitingListResponse> getShopAllWaiting(
         @LogIn Owner owner) {
-        OwnerWaitingListResponse response = ownerWaitingService.getOwnerAllWaiting(owner);
+        OwnerWaitingListResponse response = ownerWaitingService.getShopAllWaiting(owner);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/prgrms/catchtable/waiting/dto/WaitingMapper.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/dto/WaitingMapper.java
@@ -66,6 +66,7 @@ public class WaitingMapper {
             .waitingNumber(waiting.getWaitingNumber())
             .rank(rank)
             .peopleCount(waiting.getPeopleCount())
+            .status(waiting.getStatus().getDescription())
             .build();
     }
 

--- a/src/main/java/com/prgrms/catchtable/waiting/dto/WaitingMapper.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/dto/WaitingMapper.java
@@ -48,7 +48,6 @@ public class WaitingMapper {
             .shopId(waiting.getShop().getId())
             .shopName(waiting.getShop().getName())
             .peopleCount(waiting.getPeopleCount())
-            .waitingNumber(waiting.getWaitingNumber())
             .status(waiting.getStatus().getDescription())
             .build();
     }

--- a/src/main/java/com/prgrms/catchtable/waiting/dto/response/MemberWaitingHistoryListResponse.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/dto/response/MemberWaitingHistoryListResponse.java
@@ -1,7 +1,9 @@
 package com.prgrms.catchtable.waiting.dto.response;
 
 import java.util.List;
+import lombok.Builder;
 
+@Builder
 public record MemberWaitingHistoryListResponse(
     List<MemberWaitingHistoryResponse> memberWaitings
 ) {

--- a/src/main/java/com/prgrms/catchtable/waiting/dto/response/MemberWaitingHistoryResponse.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/dto/response/MemberWaitingHistoryResponse.java
@@ -8,7 +8,6 @@ public record MemberWaitingHistoryResponse(
     Long shopId,
     String shopName,
     int peopleCount,
-    int waitingNumber,
     String status
 ) {
 

--- a/src/main/java/com/prgrms/catchtable/waiting/dto/response/OwnerWaitingResponse.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/dto/response/OwnerWaitingResponse.java
@@ -7,7 +7,8 @@ public record OwnerWaitingResponse(
     Long waitingId,
     int waitingNumber,
     Long rank,
-    int peopleCount
+    int peopleCount,
+    String status
 ) {
 
 }

--- a/src/main/java/com/prgrms/catchtable/waiting/service/OwnerWaitingService.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/service/OwnerWaitingService.java
@@ -24,7 +24,7 @@ public class OwnerWaitingService {
     private final WaitingLineRepository waitingLineRepository;
 
     @Transactional(readOnly = true)
-    public OwnerWaitingListResponse getOwnerAllWaiting(Owner owner) {
+    public OwnerWaitingListResponse getShopAllWaiting(Owner owner) {
         List<Long> waitingIds = waitingLineRepository.getShopWaitingIdsInOrder(
             owner.getShop().getId());
         List<Waiting> waitings = waitingRepository.findByIds(waitingIds);

--- a/src/test/java/com/prgrms/catchtable/common/restdocs/RestDocsSupport.java
+++ b/src/test/java/com/prgrms/catchtable/common/restdocs/RestDocsSupport.java
@@ -1,11 +1,14 @@
 package com.prgrms.catchtable.common.restdocs;
 
+import static com.prgrms.catchtable.common.Role.*;
 import static com.prgrms.catchtable.common.Role.MEMBER;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.prgrms.catchtable.common.Role;
 import com.prgrms.catchtable.jwt.provider.JwtTokenProvider;
 import com.prgrms.catchtable.jwt.token.Token;
 import com.prgrms.catchtable.member.domain.Member;
+import com.prgrms.catchtable.owner.domain.Owner;
 import jakarta.servlet.ServletException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -64,6 +67,13 @@ public abstract class RestDocsSupport {
 
     public HttpHeaders getHttpHeaders(Member member) {
         Token token = jwtTokenProvider.createToken(member.getEmail(), MEMBER);
+        httpHeaders.add("AccessToken", token.getAccessToken());
+        httpHeaders.add("RefreshToken", token.getRefreshToken());
+        return httpHeaders;
+    }
+
+    public HttpHeaders getHttpHeaders(Owner owner) {
+        Token token = jwtTokenProvider.createToken(owner.getEmail(), OWNER);
         httpHeaders.add("AccessToken", token.getAccessToken());
         httpHeaders.add("RefreshToken", token.getRefreshToken());
         return httpHeaders;

--- a/src/test/java/com/prgrms/catchtable/waiting/controller/MemberWaitingControllerDocsTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/controller/MemberWaitingControllerDocsTest.java
@@ -162,7 +162,7 @@ class MemberWaitingControllerDocsTest extends RestDocsSupport {
         //given
         MemberWaitingResponse response =
             WaitingFixture.memberWaitingResponse(2,
-            PROGRESS);
+                PROGRESS);
         given(memberWaitingService.getWaiting(member)).willReturn(response);
         //when, then
         mockMvc.perform(get("/waitings")

--- a/src/test/java/com/prgrms/catchtable/waiting/controller/MemberWaitingControllerDocsTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/controller/MemberWaitingControllerDocsTest.java
@@ -1,25 +1,36 @@
 package com.prgrms.catchtable.waiting.controller;
 
+import static com.prgrms.catchtable.member.MemberFixture.member;
+import static com.prgrms.catchtable.waiting.domain.WaitingStatus.CANCELED;
+import static com.prgrms.catchtable.waiting.domain.WaitingStatus.PROGRESS;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.prgrms.catchtable.common.restdocs.RestDocsSupport;
-import com.prgrms.catchtable.member.MemberFixture;
 import com.prgrms.catchtable.member.domain.Member;
 import com.prgrms.catchtable.member.repository.MemberRepository;
 import com.prgrms.catchtable.waiting.dto.request.CreateWaitingRequest;
+import com.prgrms.catchtable.waiting.dto.response.MemberWaitingHistoryListResponse;
+import com.prgrms.catchtable.waiting.dto.response.MemberWaitingHistoryResponse;
 import com.prgrms.catchtable.waiting.dto.response.MemberWaitingResponse;
+import com.prgrms.catchtable.waiting.fixture.WaitingFixture;
 import com.prgrms.catchtable.waiting.service.MemberWaitingService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
@@ -29,7 +40,13 @@ class MemberWaitingControllerDocsTest extends RestDocsSupport {
     private MemberWaitingService memberWaitingService;
     @Autowired
     private MemberRepository memberRepository;
+    private Member member;
 
+    @BeforeEach
+    void setUp() {
+        member = member("test@naver.com");
+        memberRepository.save(member);
+    }
 
     @DisplayName("웨이팅 생성 API")
     @Test
@@ -37,18 +54,7 @@ class MemberWaitingControllerDocsTest extends RestDocsSupport {
         CreateWaitingRequest request = CreateWaitingRequest
             .builder()
             .peopleCount(2).build();
-        MemberWaitingResponse response = MemberWaitingResponse.builder()
-            .waitingId(201L)
-            .shopId(1L)
-            .shopName("shop1")
-            .waitingNumber(324)
-            .rank(20L)
-            .peopleCount(2)
-            .remainingPostponeCount(2)
-            .status("진행 중")
-            .build();
-        Member member = MemberFixture.member("test@naver.com");
-        memberRepository.save(member);
+        MemberWaitingResponse response = WaitingFixture.memberWaitingResponse(2, PROGRESS);
         given(memberWaitingService.createWaiting(1L, member, request)).willReturn(response);
 
         mockMvc.perform(post("/waitings/{shopId}", 1)
@@ -58,29 +64,185 @@ class MemberWaitingControllerDocsTest extends RestDocsSupport {
             .andExpect(status().isOk())
             .andDo(restDocs.document(
                 requestFields(
-                    fieldWithPath("peopleCount").type(JsonFieldType.NUMBER)
+                    fieldWithPath("peopleCount").type(NUMBER)
                         .description("인원수")
                 ),
                 responseFields(
-                    fieldWithPath("waitingId").type(JsonFieldType.NUMBER)
+                    fieldWithPath("waitingId").type(NUMBER)
                         .description("생성된 웨이팅 아이디"),
-                    fieldWithPath("shopId").type(JsonFieldType.NUMBER)
+                    fieldWithPath("shopId").type(NUMBER)
                         .description("상점 아이디"),
-                    fieldWithPath("shopName").type(JsonFieldType.STRING)
+                    fieldWithPath("shopName").type(STRING)
                         .description("상점 이름"),
-                    fieldWithPath("peopleCount").type(JsonFieldType.NUMBER)
+                    fieldWithPath("peopleCount").type(NUMBER)
                         .description("인원 수"),
-                    fieldWithPath("waitingNumber").type(JsonFieldType.NUMBER)
+                    fieldWithPath("waitingNumber").type(NUMBER)
                         .description("웨이팅 고유 번호"),
-                    fieldWithPath("rank").type(JsonFieldType.NUMBER)
+                    fieldWithPath("rank").type(NUMBER)
                         .description("웨이팅 순서"),
-                    fieldWithPath("remainingPostponeCount").type(JsonFieldType.NUMBER)
+                    fieldWithPath("remainingPostponeCount").type(NUMBER)
                         .description("대기 지연 잔여 횟수"),
-                    fieldWithPath("status").type(JsonFieldType.STRING)
+                    fieldWithPath("status").type(STRING)
                         .description("대기 상태")
                 )
             ));
-
-
     }
+
+    @DisplayName("웨이팅 지연 API")
+    @Test
+    void postponeWaiting() throws Exception {
+        //given
+        MemberWaitingResponse response = WaitingFixture.memberWaitingResponse(2, PROGRESS);
+        given(memberWaitingService.postponeWaiting(member)).willReturn(response);
+        //when, then
+        mockMvc.perform(patch("/waitings")
+                .contentType(APPLICATION_JSON)
+                .headers(getHttpHeaders(member)))
+            .andExpect(status().isOk())
+            .andDo(restDocs.document(
+                responseFields(
+                    fieldWithPath("waitingId").type(NUMBER)
+                        .description("생성된 웨이팅 아이디"),
+                    fieldWithPath("shopId").type(NUMBER)
+                        .description("상점 아이디"),
+                    fieldWithPath("shopName").type(STRING)
+                        .description("상점 이름"),
+                    fieldWithPath("peopleCount").type(NUMBER)
+                        .description("인원 수"),
+                    fieldWithPath("waitingNumber").type(NUMBER)
+                        .description("웨이팅 고유 번호"),
+                    fieldWithPath("rank").type(NUMBER)
+                        .description("웨이팅 순서"),
+                    fieldWithPath("remainingPostponeCount").type(NUMBER)
+                        .description("대기 지연 잔여 횟수"),
+                    fieldWithPath("status").type(STRING)
+                        .description("대기 상태")
+                )
+            ));
+    }
+
+    @DisplayName("웨이팅 취소 API")
+    @Test
+    void cancelWaiting() throws Exception {
+        //given
+        MemberWaitingResponse response = WaitingFixture.memberWaitingResponse(1,
+            CANCELED);
+
+        given(memberWaitingService.cancelWaiting(member)).willReturn(response);
+        //when, then
+        mockMvc.perform(delete("/waitings")
+                .contentType(APPLICATION_JSON)
+                .headers(getHttpHeaders(member)))
+            .andExpect(status().isOk())
+            .andDo(restDocs.document(
+                responseFields(
+                    fieldWithPath("waitingId").type(NUMBER)
+                        .description("생성된 웨이팅 아이디"),
+                    fieldWithPath("shopId").type(NUMBER)
+                        .description("상점 아이디"),
+                    fieldWithPath("shopName").type(STRING)
+                        .description("상점 이름"),
+                    fieldWithPath("peopleCount").type(NUMBER)
+                        .description("인원 수"),
+                    fieldWithPath("waitingNumber").type(NUMBER)
+                        .description("웨이팅 고유 번호"),
+                    fieldWithPath("rank").type(NUMBER)
+                        .description("웨이팅 순서"),
+                    fieldWithPath("remainingPostponeCount").type(NUMBER)
+                        .description("대기 지연 잔여 횟수"),
+                    fieldWithPath("status").type(STRING)
+                        .description("대기 상태")
+                )
+            ));
+    }
+
+    @DisplayName("회원 진행 중인 웨이팅 조회 API")
+    @Test
+    void getWaiting() throws Exception {
+        //given
+        MemberWaitingResponse response =
+            WaitingFixture.memberWaitingResponse(2,
+            PROGRESS);
+        given(memberWaitingService.getWaiting(member)).willReturn(response);
+        //when, then
+        mockMvc.perform(get("/waitings")
+                .contentType(APPLICATION_JSON)
+                .headers(getHttpHeaders(member)))
+            .andExpect(status().isOk())
+            .andDo(restDocs.document(
+                responseFields(
+                    fieldWithPath("waitingId").type(NUMBER)
+                        .description("생성된 웨이팅 아이디"),
+                    fieldWithPath("shopId").type(NUMBER)
+                        .description("상점 아이디"),
+                    fieldWithPath("shopName").type(STRING)
+                        .description("상점 이름"),
+                    fieldWithPath("peopleCount").type(NUMBER)
+                        .description("인원 수"),
+                    fieldWithPath("waitingNumber").type(NUMBER)
+                        .description("웨이팅 고유 번호"),
+                    fieldWithPath("rank").type(NUMBER)
+                        .description("웨이팅 순서"),
+                    fieldWithPath("remainingPostponeCount").type(NUMBER)
+                        .description("대기 지연 잔여 횟수"),
+                    fieldWithPath("status").type(STRING)
+                        .description("대기 상태")
+                )
+            ));
+    }
+
+    @DisplayName("회원의 웨이팅 이력 조회")
+    @Test
+    void getMemberWaitingHistory() throws Exception {
+        //given
+        MemberWaitingHistoryResponse response1 = MemberWaitingHistoryResponse.builder()
+            .waitingId(1L)
+            .shopId(77L)
+            .shopName("shop1")
+            .status("취소")
+            .peopleCount(2)
+            .build();
+        MemberWaitingHistoryResponse response2 = MemberWaitingHistoryResponse.builder()
+            .waitingId(22L)
+            .shopId(77L)
+            .shopName("shop1")
+            .status("진행중")
+            .peopleCount(2)
+            .build();
+        MemberWaitingHistoryListResponse responses = MemberWaitingHistoryListResponse.builder()
+            .memberWaitings(List.of(response1, response2))
+            .build();
+        given(memberWaitingService.getMemberWaitingHistory(member)).willReturn(responses);
+        //when, then
+        mockMvc.perform(get("/waitings/all")
+                .contentType(APPLICATION_JSON)
+                .headers(getHttpHeaders(member)))
+            .andExpect(status().isOk())
+            .andDo(restDocs.document(
+                responseFields(
+                    fieldWithPath("memberWaitings[0].waitingId").type(NUMBER)
+                        .description("회원 웨이팅 아이디"),
+                    fieldWithPath("memberWaitings[0].shopId").type(NUMBER)
+                        .description("가게 아이디"),
+                    fieldWithPath("memberWaitings[0].shopName").type(STRING)
+                        .description("가게 이름"),
+                    fieldWithPath("memberWaitings[0].peopleCount").type(NUMBER)
+                        .description("인원 수"),
+                    fieldWithPath("memberWaitings[0].status").type(STRING)
+                        .description("대기 상태"),
+                    fieldWithPath("memberWaitings[1].waitingId").type(NUMBER)
+                        .description("회원 웨이팅 아이디"),
+                    fieldWithPath("memberWaitings[1].shopId").type(NUMBER)
+                        .description("가게 아이디"),
+                    fieldWithPath("memberWaitings[1].shopName").type(STRING)
+                        .description("가게 이름"),
+                    fieldWithPath("memberWaitings[1].peopleCount").type(NUMBER)
+                        .description("인원 수"),
+                    fieldWithPath("memberWaitings[1].status").type(STRING)
+                        .description("대기 상태")
+                )
+            ));
+    }
+
+
 }

--- a/src/test/java/com/prgrms/catchtable/waiting/controller/OwnerWaitingControllerDocsTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/controller/OwnerWaitingControllerDocsTest.java
@@ -1,0 +1,133 @@
+package com.prgrms.catchtable.waiting.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.prgrms.catchtable.common.restdocs.RestDocsSupport;
+import com.prgrms.catchtable.owner.domain.Owner;
+import com.prgrms.catchtable.owner.fixture.OwnerFixture;
+import com.prgrms.catchtable.owner.repository.OwnerRepository;
+import com.prgrms.catchtable.waiting.dto.response.OwnerWaitingListResponse;
+import com.prgrms.catchtable.waiting.dto.response.OwnerWaitingResponse;
+import com.prgrms.catchtable.waiting.service.OwnerWaitingService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+class OwnerWaitingControllerDocsTest extends RestDocsSupport {
+
+    @MockBean
+    private OwnerWaitingService ownerWaitingService;
+
+    @Autowired
+    private OwnerRepository ownerRepository;
+
+    private Owner owner;
+
+    @BeforeEach
+    void setUp() {
+        owner = OwnerFixture.getOwner("hyun@gmail.com", "hyun1234");
+        ownerRepository.save(owner);
+    }
+
+    @DisplayName("웨이팅 입장 API")
+    @Test
+    void entryWaiting() throws Exception {
+        //given
+        OwnerWaitingResponse response = OwnerWaitingResponse.builder()
+            .waitingId(1L)
+            .waitingNumber(20)
+            .rank(1L)
+            .peopleCount(2)
+            .status("진행 중")
+            .build();
+        given(ownerWaitingService.entryWaiting(owner)).willReturn(response);
+        //when, then
+        mockMvc.perform(patch("/owner/waitings")
+                .contentType(APPLICATION_JSON)
+                .headers(getHttpHeaders(owner)))
+            .andExpect(status().isOk())
+            .andDo(restDocs.document(
+                responseFields(
+                    fieldWithPath("waitingId").type(NUMBER)
+                        .description("회원 웨이팅 아이디"),
+                    fieldWithPath("waitingNumber").type(NUMBER)
+                        .description("웨이팅 고유 번호"),
+                    fieldWithPath("rank").type(NUMBER)
+                        .description("웨이팅 순서"),
+                    fieldWithPath("peopleCount").type(NUMBER)
+                        .description("인원 수"),
+                    fieldWithPath("status").type(STRING)
+                        .description("대기 상태")
+                )
+            ));
+
+    }
+
+    @DisplayName("owner 가게의 웨이팅 목록 조회")
+    @Test
+    void getShopAllWaiting() throws Exception {
+        //given
+        OwnerWaitingResponse response1 = OwnerWaitingResponse.builder()
+            .waitingId(1L)
+            .waitingNumber(20)
+            .rank(1L)
+            .peopleCount(2)
+            .status("진행 중")
+            .build();
+        OwnerWaitingResponse response2 = OwnerWaitingResponse.builder()
+            .waitingId(2L)
+            .waitingNumber(21)
+            .rank(2L)
+            .peopleCount(2)
+            .status("진행 중")
+            .build();
+        OwnerWaitingListResponse responses = OwnerWaitingListResponse.builder()
+            .shopWaitings(List.of(response1, response2))
+            .build();
+
+        given(ownerWaitingService.getShopAllWaiting(owner)).willReturn(responses);
+
+        //when, then
+        mockMvc.perform(get("/owner/waitings")
+                .contentType(APPLICATION_JSON)
+                .headers(getHttpHeaders(owner)))
+            .andExpect(status().isOk())
+            .andDo(restDocs.document(
+                responseFields(
+                    fieldWithPath("shopWaitings[0].waitingId").type(NUMBER)
+                        .description("회원 웨이팅 아이디"),
+                    fieldWithPath("shopWaitings[0].waitingNumber").type(NUMBER)
+                        .description("웨이팅 고유 번호"),
+                    fieldWithPath("shopWaitings[0].rank").type(NUMBER)
+                        .description("웨이팅 순서"),
+                    fieldWithPath("shopWaitings[0].peopleCount").type(NUMBER)
+                        .description("인원 수"),
+                    fieldWithPath("shopWaitings[0].status").type(STRING)
+                        .description("대기 상태"),
+                    fieldWithPath("shopWaitings[1].waitingId").type(NUMBER)
+                        .description("회원 웨이팅 아이디"),
+                    fieldWithPath("shopWaitings[1].waitingNumber").type(NUMBER)
+                        .description("웨이팅 고유 번호"),
+                    fieldWithPath("shopWaitings[1].rank").type(NUMBER)
+                        .description("웨이팅 순서"),
+                    fieldWithPath("shopWaitings[1].peopleCount").type(NUMBER)
+                        .description("인원 수"),
+                    fieldWithPath("shopWaitings[1].status").type(STRING)
+                        .description("대기 상태")
+                )
+            ));
+    }
+}

--- a/src/test/java/com/prgrms/catchtable/waiting/fixture/WaitingFixture.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/fixture/WaitingFixture.java
@@ -29,7 +29,8 @@ public class WaitingFixture {
         return waiting;
     }
 
-    public static MemberWaitingResponse memberWaitingResponse(int remainingPostponeCount, WaitingStatus status){
+    public static MemberWaitingResponse memberWaitingResponse(int remainingPostponeCount,
+        WaitingStatus status) {
         return MemberWaitingResponse.builder()
             .waitingId(1L)
             .shopId(1L)

--- a/src/test/java/com/prgrms/catchtable/waiting/fixture/WaitingFixture.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/fixture/WaitingFixture.java
@@ -3,6 +3,8 @@ package com.prgrms.catchtable.waiting.fixture;
 import com.prgrms.catchtable.member.domain.Member;
 import com.prgrms.catchtable.shop.domain.Shop;
 import com.prgrms.catchtable.waiting.domain.Waiting;
+import com.prgrms.catchtable.waiting.domain.WaitingStatus;
+import com.prgrms.catchtable.waiting.dto.response.MemberWaitingResponse;
 
 public class WaitingFixture {
 
@@ -25,5 +27,18 @@ public class WaitingFixture {
         Waiting waiting = progressWaiting(member, shop, waitingNumber);
         waiting.changeStatusCanceled();
         return waiting;
+    }
+
+    public static MemberWaitingResponse memberWaitingResponse(int remainingPostponeCount, WaitingStatus status){
+        return MemberWaitingResponse.builder()
+            .waitingId(1L)
+            .shopId(1L)
+            .shopName("shop1")
+            .waitingNumber(324)
+            .rank(20L)
+            .peopleCount(remainingPostponeCount)
+            .remainingPostponeCount(2)
+            .status(status.getDescription())
+            .build();
     }
 }

--- a/src/test/java/com/prgrms/catchtable/waiting/service/MemberWaitingServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/service/MemberWaitingServiceTest.java
@@ -169,8 +169,7 @@ class MemberWaitingServiceTest {
         //then
         assertAll(
             assertThat(response.memberWaitings().get(0).peopleCount())::isNotNull,
-            assertThat(response.memberWaitings().get(0).status())::isNotNull,
-            assertThat(response.memberWaitings().get(0).shopName())::isNotNull
+            assertThat(response.memberWaitings().get(0).status())::isNotNull
         );
     }
 }

--- a/src/test/java/com/prgrms/catchtable/waiting/service/MemberWaitingServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/service/MemberWaitingServiceTest.java
@@ -169,8 +169,8 @@ class MemberWaitingServiceTest {
         //then
         assertAll(
             assertThat(response.memberWaitings().get(0).peopleCount())::isNotNull,
-            assertThat(response.memberWaitings().get(0).waitingNumber())::isNotNull,
-            assertThat(response.memberWaitings().get(0).status())::isNotNull
+            assertThat(response.memberWaitings().get(0).status())::isNotNull,
+            assertThat(response.memberWaitings().get(0).shopName())::isNotNull
         );
     }
 }

--- a/src/test/java/com/prgrms/catchtable/waiting/service/OwnerWaitingServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/service/OwnerWaitingServiceTest.java
@@ -40,9 +40,9 @@ class OwnerWaitingServiceTest {
     @InjectMocks
     private OwnerWaitingService ownerWaitingService;
 
-    @DisplayName("owner의 waiting 목록을 모두 가져온다.")
+    @DisplayName("가게의 waiting 목록을 모두 가져온다.")
     @Test
-    void getOwnerAllWaiting() {
+    void getShopAllWaiting() {
         //given
         List<Long> waitingIds = List.of(1L, 2L);
         Member member1 = mock(Member.class);
@@ -59,7 +59,7 @@ class OwnerWaitingServiceTest {
         given(waitingRepository.findByIds(waitingIds)).willReturn(List.of(waiting1, waiting2));
 
         //when
-        OwnerWaitingListResponse response = ownerWaitingService.getOwnerAllWaiting(owner);
+        OwnerWaitingListResponse response = ownerWaitingService.getShopAllWaiting(owner);
 
         //then
         assertAll(


### PR DESCRIPTION
### ⛏ 작업 상세 내용

-  api명 수정
   - getOwnerAllWaiting -> getShopAllWaiting
- 응답 dto 수정
  - ownerWaitingResponse status 추가
  - MemberWaitingHistoryResponse waitingNumber 필드 삭제
- OwnerWaitingController 단위 테스트
- MemberWaitingController 단위 테스트
- waiting.adoc에 스니펫 추가

### 📝 작업 요약

- waiting api rest docs 명세
