### PR TITLE
feat : 예약 사전 알림 기능 추가

### DIFF
--- a/src/main/java/com/prgrms/catchtable/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/repository/ReservationRepository.java
@@ -2,6 +2,7 @@ package com.prgrms.catchtable.reservation.repository;
 
 import com.prgrms.catchtable.member.domain.Member;
 import com.prgrms.catchtable.reservation.domain.Reservation;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -28,4 +29,15 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
         + "join fetch rt.shop s "
         + "where s.id = :shopId")
     List<Reservation> findAllWithReservationTimeAndShopByShopId(@Param("shopId") Long shopId);
+
+    @Query("select r from Reservation r "
+        + "join fetch r.member m "
+        + "join fetch r.reservationTime rt "
+        + "where rt.time  >= :startOfDay "
+        + "and rt.time < :endOfDay " // endOfDay는 다음날 00시00분이므로 그 시간보다 미만 조건
+        + "and r.status = 'COMPLETED'")
+    List<Reservation> findAllTodayReservation(
+        @Param("startOfDay") LocalDateTime startOfDay,
+        @Param("endOfDay") LocalDateTime endOfDay
+    );
 }

--- a/src/main/java/com/prgrms/catchtable/reservation/scheduler/ReservationNotificationScheduler.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/scheduler/ReservationNotificationScheduler.java
@@ -10,7 +10,6 @@ import com.prgrms.catchtable.reservation.domain.Reservation;
 import com.prgrms.catchtable.reservation.repository.ReservationRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -21,13 +20,14 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class ReservationNotificationScheduler {
+
     private final ReservationRepository reservationRepository;
     private final ApplicationEventPublisher publisher;
 
     private List<Reservation> reservations = new ArrayList<>();
 
     @Scheduled(cron = "0 0 0 * * *") // 매일 자정에 당일의 예약 다 가져옴
-    public void getAllTodayReservation(){
+    public void getAllTodayReservation() {
 
         LocalDate today = LocalDate.now();
 
@@ -35,11 +35,12 @@ public class ReservationNotificationScheduler {
         LocalDateTime endOfDay = today.plusDays(1).atStartOfDay(); // 하루의 끝 (내일의 00시 00분)
 
         reservations = reservationRepository.findAllTodayReservation(startOfDay, endOfDay);
-        reservations.forEach(reservation -> reservation.getReservationTime().getTime().truncatedTo(MINUTES)); //예약시간의 '초' 다 버림
+        reservations.forEach(reservation -> reservation.getReservationTime().getTime()
+            .truncatedTo(MINUTES)); //예약시간의 '초' 다 버림
     }
 
-    @Scheduled(cron = "0 * * * * *") // 1분마다 예약 시간 체크 (1시간 전인 지, 입장시간 됐는 지)
-    public void sendReservationMessage(){
+    @Scheduled(cron = "0 * * * * *") // 1분마다 예약 시간 체크 후 알림 발송 (1시간 전인 지, 입장시간 됐는 지)
+    public void sendReservationMessage() {
 
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime nowTime = now.truncatedTo(MINUTES); // '분'까지만 가져옴 (초 버림)
@@ -48,19 +49,20 @@ public class ReservationNotificationScheduler {
 
             LocalDateTime reservationTime = r.getReservationTime().getTime();
 
-            if (nowTime.isEqual(reservationTime)) { // 예약시간이 한시간 이하로 남았다면
+            if (nowTime.isEqual(reservationTime.minusHours(1))) { // 예약시간이 한시간 남았다면
                 sendMessage(r, reservationTime, RESERVATION_ONE_HOUR_LEFT); // 한시간 남았다고 알림 발송
                 continue;
             }
 
-            if(nowTime.isEqual(reservationTime)){ // 현재시간이 예약시간이 됐다면
-                sendMessage(r, reservationTime, RESERVATION_TIME_OUT);
+            if (nowTime.isEqual(reservationTime)) { // 현재시간이 예약시간이 됐다면
+                sendMessage(r, reservationTime, RESERVATION_TIME_OUT); // 예약 시간 됐다고 알림 발송
                 reservations.remove(r); //예약 입장 알림 보낸 예약은 순회 리스트에서 삭제
             }
         }
     }
 
-    private void sendMessage(Reservation r, LocalDateTime reservationTime, NotificationContent content) {
+    private void sendMessage(Reservation r, LocalDateTime reservationTime,
+        NotificationContent content) {
         SendMessageToMemberRequest request = new SendMessageToMemberRequest(
             r.getMember(),
             content.getMessage(reservationTime.toString())

--- a/src/main/java/com/prgrms/catchtable/reservation/scheduler/ReservationNotificationScheduler.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/scheduler/ReservationNotificationScheduler.java
@@ -1,0 +1,70 @@
+package com.prgrms.catchtable.reservation.scheduler;
+
+import static com.prgrms.catchtable.common.notification.NotificationContent.RESERVATION_ONE_HOUR_LEFT;
+import static com.prgrms.catchtable.common.notification.NotificationContent.RESERVATION_TIME_OUT;
+import static java.time.temporal.ChronoUnit.MINUTES;
+
+import com.prgrms.catchtable.common.notification.NotificationContent;
+import com.prgrms.catchtable.notification.dto.request.SendMessageToMemberRequest;
+import com.prgrms.catchtable.reservation.domain.Reservation;
+import com.prgrms.catchtable.reservation.repository.ReservationRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationNotificationScheduler {
+    private final ReservationRepository reservationRepository;
+    private final ApplicationEventPublisher publisher;
+
+    private List<Reservation> reservations = new ArrayList<>();
+
+    @Scheduled(cron = "0 0 0 * * *") // 매일 자정에 당일의 예약 다 가져옴
+    public void getAllTodayReservation(){
+
+        LocalDate today = LocalDate.now();
+
+        LocalDateTime startOfDay = today.atStartOfDay(); // 하루의 시작 (오늘의 00시 00분)
+        LocalDateTime endOfDay = today.plusDays(1).atStartOfDay(); // 하루의 끝 (내일의 00시 00분)
+
+        reservations = reservationRepository.findAllTodayReservation(startOfDay, endOfDay);
+        reservations.forEach(reservation -> reservation.getReservationTime().getTime().truncatedTo(MINUTES)); //예약시간의 '초' 다 버림
+    }
+
+    @Scheduled(cron = "0 * * * * *") // 1분마다 예약 시간 체크 (1시간 전인 지, 입장시간 됐는 지)
+    public void sendReservationMessage(){
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime nowTime = now.truncatedTo(MINUTES); // '분'까지만 가져옴 (초 버림)
+
+        for (Reservation r : reservations) { // 당일의 예약 리스트를 돌며 시간 만족하는 예약은 알림 발송
+
+            LocalDateTime reservationTime = r.getReservationTime().getTime();
+
+            if (nowTime.isEqual(reservationTime)) { // 예약시간이 한시간 이하로 남았다면
+                sendMessage(r, reservationTime, RESERVATION_ONE_HOUR_LEFT); // 한시간 남았다고 알림 발송
+                continue;
+            }
+
+            if(nowTime.isEqual(reservationTime)){ // 현재시간이 예약시간이 됐다면
+                sendMessage(r, reservationTime, RESERVATION_TIME_OUT);
+                reservations.remove(r); //예약 입장 알림 보낸 예약은 순회 리스트에서 삭제
+            }
+        }
+    }
+
+    private void sendMessage(Reservation r, LocalDateTime reservationTime, NotificationContent content) {
+        SendMessageToMemberRequest request = new SendMessageToMemberRequest(
+            r.getMember(),
+            content.getMessage(reservationTime.toString())
+        );
+        publisher.publishEvent(request);
+    }
+}

--- a/src/main/java/com/prgrms/catchtable/reservation/scheduler/SchedulerConfig.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/scheduler/SchedulerConfig.java
@@ -1,0 +1,10 @@
+package com.prgrms.catchtable.reservation.scheduler;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+
+}

--- a/src/test/java/com/prgrms/catchtable/reservation/repository/ReservationRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/repository/ReservationRepositoryTest.java
@@ -16,7 +16,6 @@ import com.prgrms.catchtable.shop.fixture.ShopFixture;
 import com.prgrms.catchtable.shop.repository.ShopRepository;
 import java.time.LocalDateTime;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -123,27 +122,28 @@ class ReservationRepositoryTest {
 
     @Test
     @DisplayName("오늘 날짜인 예약들만 가져올 수 있다.")
-    void findAllTodayReservation(){
+    void findAllTodayReservation() {
         Member member = MemberFixture.member("dls@gmail.com");
         Member savedMember = memberRepository.save(member);
         Shop shop = ShopFixture.shop();
         Shop savedShop = shopRepository.save(shop);
 
-        LocalDateTime startOfDay = LocalDateTime.of(2024,1,2,0,0);
-        LocalDateTime endOfDay = LocalDateTime.of(2024,1,3,0,0);
+        LocalDateTime startOfDay = LocalDateTime.of(2024, 1, 2, 0, 0);
+        LocalDateTime endOfDay = LocalDateTime.of(2024, 1, 3, 0, 0);
 
         ReservationTime time1 = ReservationTime.builder()
-            .time(LocalDateTime.of(2024,1,2,19,30))
+            .time(LocalDateTime.of(2024, 1, 2, 19, 30))
             .build();
         ReservationTime time2 = ReservationTime.builder()
-            .time(LocalDateTime.of(2024,1,3,15,30))
+            .time(LocalDateTime.of(2024, 1, 3, 15, 30))
             .build();
 
         time1.insertShop(savedShop); //예약시간 - 매장 매핑
         time2.insertShop(savedShop);
         reservationTimeRepository.saveAll(List.of(time1, time2));
 
-        Reservation reservation1 = ReservationFixture.getReservation(time1, savedMember); // 예약시간 - 예약 - 회원 매핑
+        Reservation reservation1 = ReservationFixture.getReservation(time1,
+            savedMember); // 예약시간 - 예약 - 회원 매핑
         Reservation reservation2 = ReservationFixture.getReservation(time2, savedMember);
 
         Reservation savedReservation1 = reservationRepository.save(reservation1);

--- a/src/test/java/com/prgrms/catchtable/reservation/repository/ReservationRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/repository/ReservationRepositoryTest.java
@@ -14,7 +14,9 @@ import com.prgrms.catchtable.reservation.fixture.ReservationFixture;
 import com.prgrms.catchtable.shop.domain.Shop;
 import com.prgrms.catchtable.shop.fixture.ShopFixture;
 import com.prgrms.catchtable.shop.repository.ShopRepository;
+import java.time.LocalDateTime;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -117,6 +119,44 @@ class ReservationRepositoryTest {
             () -> assertThat(all).contains(reservation),
             () -> assertThat(all).doesNotContain(otherReservation)
         );
+    }
+
+    @Test
+    @DisplayName("오늘 날짜인 예약들만 가져올 수 있다.")
+    void findAllTodayReservation(){
+        Member member = MemberFixture.member("dls@gmail.com");
+        Member savedMember = memberRepository.save(member);
+        Shop shop = ShopFixture.shop();
+        Shop savedShop = shopRepository.save(shop);
+
+        LocalDateTime startOfDay = LocalDateTime.of(2024,1,2,0,0);
+        LocalDateTime endOfDay = LocalDateTime.of(2024,1,3,0,0);
+
+        ReservationTime time1 = ReservationTime.builder()
+            .time(LocalDateTime.of(2024,1,2,19,30))
+            .build();
+        ReservationTime time2 = ReservationTime.builder()
+            .time(LocalDateTime.of(2024,1,3,15,30))
+            .build();
+
+        time1.insertShop(savedShop); //예약시간 - 매장 매핑
+        time2.insertShop(savedShop);
+        reservationTimeRepository.saveAll(List.of(time1, time2));
+
+        Reservation reservation1 = ReservationFixture.getReservation(time1, savedMember); // 예약시간 - 예약 - 회원 매핑
+        Reservation reservation2 = ReservationFixture.getReservation(time2, savedMember);
+
+        Reservation savedReservation1 = reservationRepository.save(reservation1);
+        Reservation savedReservation2 = reservationRepository.save(reservation2);
+
+        List<Reservation> reservations = reservationRepository.findAllTodayReservation(
+            startOfDay,
+            endOfDay
+        ); //1월 2일의 예약만 조회 -> reservation1만 조회될 것
+
+        assertThat(reservations).contains(savedReservation1); // 시간 범위 안에 있으므로 가져와야됨
+        assertThat(reservations).doesNotContain(savedReservation2); // 범위 밖이니 가져오면 안됨
+
     }
 
 }


### PR DESCRIPTION
- close #100 
### ⛏ 작업 상세 내용

- 당일의 예약 리스트 가져오는 쿼리 추가
- 예약 알림 스케줄러 구현
    - 매일 자정마다 당일의 예약리스트 가져옴
    - 하루동안 1분마다 예약 시간 체크
    - 1시간 남았을 때와 예약시간이 됐을 때 알림 발송

### 📝 작업 요약

- 예약 사전 알림 스케줄러 구현

### **☑️** 중점적으로 리뷰 할 부분

- 알림 스케줄러 (주석 다 달아놓았으니 천천히 보고 의견 주십쇼~)
- 당일 예약리스트 가져오는 쿼리
