### PR TITLE
feature : 웨이팅 알림 기능 구현

### DIFF
--- a/src/docs/asciidoc/api/waiting/waiting.adoc
+++ b/src/docs/asciidoc/api/waiting/waiting.adoc
@@ -11,6 +11,28 @@ include::{snippets}/member-waiting-controller-docs-test/create-waiting/request-f
 include::{snippets}/member-waiting-controller-docs-test/create-waiting/http-response.adoc[]
 include::{snippets}/member-waiting-controller-docs-test/create-waiting/response-fields.adoc[]
 
+=== 회원 진행 중인 웨이팅 조회 API
+
+==== HTTP Request
+
+include::{snippets}/member-waiting-controller-docs-test/get-waiting/http-request.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/member-waiting-controller-docs-test/get-waiting/http-response.adoc[]
+include::{snippets}/member-waiting-controller-docs-test/get-waiting/response-fields.adoc[]
+
+=== 회원 웨이팅 이력 조회 API
+
+==== HTTP Request
+
+include::{snippets}/member-waiting-controller-docs-test/get-member-waiting-history/http-request.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/member-waiting-controller-docs-test/get-member-waiting-history/http-response.adoc[]
+include::{snippets}/member-waiting-controller-docs-test/get-member-waiting-history/response-fields.adoc[]
+
 === 웨이팅 지연 API
 
 ==== HTTP Request
@@ -33,17 +55,6 @@ include::{snippets}/member-waiting-controller-docs-test/cancel-waiting/http-requ
 include::{snippets}/member-waiting-controller-docs-test/cancel-waiting/http-response.adoc[]
 include::{snippets}/member-waiting-controller-docs-test/cancel-waiting/response-fields.adoc[]
 
-=== 회원 진행 중인 웨이팅 조회 API
-
-==== HTTP Request
-
-include::{snippets}/member-waiting-controller-docs-test/get-waiting/http-request.adoc[]
-
-==== HTTP Response
-
-include::{snippets}/member-waiting-controller-docs-test/get-waiting/http-response.adoc[]
-include::{snippets}/member-waiting-controller-docs-test/get-waiting/response-fields.adoc[]
-
 
 === 웨이팅 입장 API
 
@@ -56,7 +67,7 @@ include::{snippets}/owner-waiting-controller-docs-test/entry-waiting/http-reques
 include::{snippets}/owner-waiting-controller-docs-test/entry-waiting/http-response.adoc[]
 include::{snippets}/owner-waiting-controller-docs-test/entry-waiting/response-fields.adoc[]
 
-=== 가게 웨이팅 이력 조회 API
+=== 가게 웨이팅 조회 API
 
 ==== HTTP Request
 

--- a/src/main/java/com/prgrms/catchtable/common/exception/ErrorCode.java
+++ b/src/main/java/com/prgrms/catchtable/common/exception/ErrorCode.java
@@ -21,7 +21,7 @@ public enum ErrorCode {
     SLACK_ID_IS_WRONG("요청한 슬랙 Id를 찾을 수 없거나 잘못 되었습니다"),
 
     CAN_NOT_COMPLETE_WAITING("입장 처리가 불가한 대기 상태입니다."),
-    EXISTING_MEMBER_WAITING("이미 회원이 웨이팅 중인 가게가 존재합니다."),
+    ALREADY_PROGRESS_WAITING_EXISTS("이미 회원이 웨이팅 중인 가게가 존재합니다."),
     ALREADY_END_LINE("이미 맨뒤라 웨이팅을 미룰 수 없습니다."),
     NOT_EXIST_PROGRESS_WAITING("진행 중인 웨이팅이 존재하지 않습니다."),
 

--- a/src/main/java/com/prgrms/catchtable/common/notification/WaitingNotificationContent.java
+++ b/src/main/java/com/prgrms/catchtable/common/notification/WaitingNotificationContent.java
@@ -1,0 +1,15 @@
+package com.prgrms.catchtable.common.notification;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum WaitingNotificationContent {
+    REGISTERED("웨이팅이 등록되었습니다."),
+    CANCELED("웨이팅이 취소되었습니다."),
+
+    THIRD_RANK("3번째 순서로 곧 입장하실 차례입니다.");
+
+    private final String message;
+}

--- a/src/main/java/com/prgrms/catchtable/common/notification/WaitingNotificationContent.java
+++ b/src/main/java/com/prgrms/catchtable/common/notification/WaitingNotificationContent.java
@@ -8,11 +8,13 @@ import lombok.RequiredArgsConstructor;
 public enum WaitingNotificationContent {
     MEMBER_CREATED("웨이팅이 등록되었습니다.\n내 순서 : %d번째"),
     MEMBER_CANCELED("웨이팅이 취소되었습니다."),
+    MEMBER_COMPLETED("가게에 입장 처리되었습니다."),
     MEMBER_ENTRY("웨이팅 입장할 차례입니다."),
     MEMBER_POSTPONED("웨이팅 순서를 %d번으로 미뤘습니다."),
     THIRD_RANK("3번째 순서로 곧 입장하실 차례입니다."),
+    FIRST_RANK("입장할 순서예요! 지금 매장으로 와주세요."),
     OWNER_CREATED("%d번째 웨이팅이 등록되었습니다."),
     OWNER_CANCELED("%d번째 웨이팅이 취소되었습니다.");
 
-    private final String message;
+    private final String content;
 }

--- a/src/main/java/com/prgrms/catchtable/common/notification/WaitingNotificationContent.java
+++ b/src/main/java/com/prgrms/catchtable/common/notification/WaitingNotificationContent.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public enum WaitingNotificationContent {
-    REGISTERED("웨이팅이 등록되었습니다."),
+    REGISTERED("웨이팅이 등록되었습니다.\n내 순서 : %d번째"),
     CANCELED("웨이팅이 취소되었습니다."),
 
     THIRD_RANK("3번째 순서로 곧 입장하실 차례입니다.");

--- a/src/main/java/com/prgrms/catchtable/common/notification/WaitingNotificationContent.java
+++ b/src/main/java/com/prgrms/catchtable/common/notification/WaitingNotificationContent.java
@@ -6,10 +6,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public enum WaitingNotificationContent {
-    REGISTERED("웨이팅이 등록되었습니다.\n내 순서 : %d번째"),
-    CANCELED("웨이팅이 취소되었습니다."),
-
-    THIRD_RANK("3번째 순서로 곧 입장하실 차례입니다.");
+    MEMBER_CREATED("웨이팅이 등록되었습니다.\n내 순서 : %d번째"),
+    MEMBER_CANCELED("웨이팅이 취소되었습니다."),
+    MEMBER_ENTRY("웨이팅 입장할 차례입니다."),
+    MEMBER_POSTPONED("웨이팅 순서를 %d번으로 미뤘습니다."),
+    THIRD_RANK("3번째 순서로 곧 입장하실 차례입니다."),
+    OWNER_CREATED("%d번째 웨이팅이 등록되었습니다."),
+    OWNER_CANCELED("%d번째 웨이팅이 취소되었습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/prgrms/catchtable/waiting/controller/MemberWaitingController.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/controller/MemberWaitingController.java
@@ -55,10 +55,10 @@ public class MemberWaitingController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/all")
-    public ResponseEntity<MemberWaitingHistoryListResponse> getMemberWaitingHistory(
+    @GetMapping("/history")
+    public ResponseEntity<MemberWaitingHistoryListResponse> getWaitingHistory(
         @LogIn Member member) {
-        MemberWaitingHistoryListResponse response = memberWaitingService.getMemberWaitingHistory(
+        MemberWaitingHistoryListResponse response = memberWaitingService.getWaitingHistory(
             member);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/prgrms/catchtable/waiting/controller/OwnerWaitingController.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/controller/OwnerWaitingController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
-@RequestMapping("owner/waitings")
+@RequestMapping("owners/waitings")
 @RestController
 public class OwnerWaitingController {
 

--- a/src/main/java/com/prgrms/catchtable/waiting/domain/WaitingStatus.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/domain/WaitingStatus.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum WaitingStatus {
     PROGRESS("진행 중"),
-    COMPLETED("입장"),
+    COMPLETED("입장 완료"),
     CANCELED("취소"),
     NO_SHOW("노쇼");
 

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/WaitingRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/WaitingRepository.java
@@ -15,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 public interface WaitingRepository extends JpaRepository<Waiting, Long> {
 
-    boolean existsByMember(Member member);
+    boolean existsByMemberAndStatus(Member member, WaitingStatus status);
 
     Long countByShopAndCreatedAtBetween(Shop shop, LocalDateTime start, LocalDateTime end);
 

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/WaitingRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/WaitingRepository.java
@@ -28,9 +28,13 @@ public interface WaitingRepository extends JpaRepository<Waiting, Long> {
     List<Waiting> findByIds(@Param("ids") List<Long> ids);
 
     @Query("select w from Waiting w "
+        + "join fetch w.member where w.id = :waitingId")
+    Waiting findWaitingWithMember(@Param("waitingId") Long waitingId);
+
+    @Query("select w from Waiting w "
         + "join fetch w.shop "
         + "join fetch w.member where w.member = :member")
-    List<Waiting> findWaitingWithMember(@Param("member") Member member);
+    List<Waiting> findWaitingWithMemberAndShop(@Param("member") Member member);
 
     @Transactional
     @Modifying(clearAutomatically = true)

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepository.java
@@ -72,6 +72,18 @@ public class BasicWaitingLineRepository implements WaitingLineRepository {
         return -1L;
     }
 
+    public Long findRankThirdValue(Long shopId) {
+        Queue<Long> waitingLine = waitingLines.get(shopId);
+        int index = 0;
+        for (Long element : waitingLine) {
+            if (index == 2) {
+                return element;
+            }
+            index++;
+        }
+        return null;
+    }
+
     public Long getWaitingLineSize(Long shopId) { //postpone에서 사용
         Queue<Long> waitingLine = waitingLines.get(shopId);
         return (long) (waitingLine != null ? waitingLine.size() : 0);

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepository.java
@@ -72,11 +72,11 @@ public class BasicWaitingLineRepository implements WaitingLineRepository {
         return -1L;
     }
 
-    public Long findThirdRankValue(Long shopId) {
+    public Long findRankValue(Long shopId,int rank) {
         Queue<Long> waitingLine = waitingLines.get(shopId);
         int index = 0;
         for (Long element : waitingLine) {
-            if (index == 2) {
+            if (index == rank-1) {
                 return element;
             }
             index++;

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepository.java
@@ -74,11 +74,11 @@ public class BasicWaitingLineRepository implements WaitingLineRepository {
         return -1L;
     }
 
-    public Long findRankValue(Long shopId,int rank) {
+    public Long findRankValue(Long shopId, int rank) {
         Queue<Long> waitingLine = waitingLines.get(shopId);
         int index = 0;
         for (Long element : waitingLine) {
-            if (index == rank-1) {
+            if (index == rank - 1) {
                 return element;
             }
             index++;

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepository.java
@@ -20,9 +20,10 @@ public class BasicWaitingLineRepository implements WaitingLineRepository {
 
     public final Map<Long, Queue<Long>> waitingLines = new ConcurrentHashMap<>();
 
-    public void save(Long shopId, Long waitingId) {
+    public Long save(Long shopId, Long waitingId) {
         Queue<Long> waitingLine = waitingLines.computeIfAbsent(shopId, k -> new LinkedList<>());
         waitingLine.add(waitingId);
+        return findRank(shopId, waitingId);
     }
 
     public Long entry(Long shopId) {
@@ -46,7 +47,7 @@ public class BasicWaitingLineRepository implements WaitingLineRepository {
         }
     }
 
-    public void postpone(Long shopId, Long waitingId) {
+    public Long postpone(Long shopId, Long waitingId) {
         Queue<Long> waitingLine = waitingLines.get(shopId);
         validateIfWaitingExists(waitingLine, waitingId);
         validateIfPostponeAvailable(shopId, waitingId);
@@ -57,6 +58,7 @@ public class BasicWaitingLineRepository implements WaitingLineRepository {
                 break;
             }
         }
+        return findRank(shopId, waitingId);
     }
 
     public Long findRank(Long shopId, Long waitingId) {

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepository.java
@@ -72,7 +72,7 @@ public class BasicWaitingLineRepository implements WaitingLineRepository {
         return -1L;
     }
 
-    public Long findRankThirdValue(Long shopId) {
+    public Long findThirdRankValue(Long shopId) {
         Queue<Long> waitingLine = waitingLines.get(shopId);
         int index = 0;
         for (Long element : waitingLine) {

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepository.java
@@ -123,7 +123,7 @@ public class RedisWaitingLineRepository implements WaitingLineRepository {
         return getWaitingLineSize(shopId) - index;
     }
 
-    public Long findRankThirdValue(Long shopId) {
+    public Long findThirdRankValue(Long shopId) {
         String waitingId = redisTemplate.opsForList().index("s" + shopId, -3);
         if (waitingId == null) {
             return null;

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepository.java
@@ -68,7 +68,7 @@ public class RedisWaitingLineRepository implements WaitingLineRepository {
     public void postpone(Long shopId, Long waitingId) {
         validateIfWaitingExists(shopId, waitingId);
         validateIfPostponeAvailable(shopId, waitingId);
-        String key = "s"+shopId;
+        String key = "s" + shopId;
         if (Objects.equals(findRank(shopId, waitingId), getWaitingLineSize(shopId))) {
             throw new BadRequestCustomException(ALREADY_END_LINE);
         }

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepository.java
@@ -123,6 +123,15 @@ public class RedisWaitingLineRepository implements WaitingLineRepository {
         return getWaitingLineSize(shopId) - index;
     }
 
+    public Long findRankThirdValue(Long shopId) {
+        String waitingId = redisTemplate.opsForList().index("s" + shopId, -3);
+        if (waitingId == null) {
+            return null;
+        }
+        return Long.valueOf(waitingId);
+    }
+
+
     public Long getWaitingLineSize(Long shopId) {
         return redisTemplate.opsForList().size("s" + shopId);
     }

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepository.java
@@ -98,8 +98,8 @@ public class RedisWaitingLineRepository implements WaitingLineRepository {
         return getWaitingLineSize(shopId) - index;
     }
 
-    public Long findThirdRankValue(Long shopId) {
-        String waitingId = redisTemplate.opsForList().index("s" + shopId, -3);
+    public Long findRankValue(Long shopId, int rank) {
+        String waitingId = redisTemplate.opsForList().index("s" + shopId, -rank);
         if (waitingId == null) {
             return null;
         }

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepository.java
@@ -131,7 +131,6 @@ public class RedisWaitingLineRepository implements WaitingLineRepository {
         return Long.valueOf(waitingId);
     }
 
-
     public Long getWaitingLineSize(Long shopId) {
         return redisTemplate.opsForList().size("s" + shopId);
     }
@@ -153,10 +152,6 @@ public class RedisWaitingLineRepository implements WaitingLineRepository {
 
     public void printWaitingLine(Long shopId) {
         List<String> waitingLine = redisTemplate.opsForList().range("s" + shopId, 0, -1);
-        if (waitingLine != null) {
-            log.info("Queue: {}", waitingLine);
-        } else {
-            log.warn("Queue is empty or not found for Shop ID: {}", shopId);
-        }
+        log.info("Queue: {}", waitingLine);
     }
 }

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepository.java
@@ -12,9 +12,6 @@ import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Primary;
-import org.springframework.dao.DataAccessException;
-import org.springframework.data.redis.core.RedisOperations;
-import org.springframework.data.redis.core.SessionCallback;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
@@ -26,21 +23,9 @@ public class RedisWaitingLineRepository implements WaitingLineRepository {
 
     private final StringRedisTemplate redisTemplate;
 
-    public void save(Long shopId, Long waitingId) {
-        redisTemplate.execute(new SessionCallback<>() {
-            @Override
-            public <K, V> Object execute(RedisOperations<K, V> operations)
-                throws DataAccessException {
-                try {
-                    operations.multi();
-                    redisTemplate.opsForList().leftPush("s" + shopId, waitingId.toString());
-                    return operations.exec();
-                } catch (Exception e) {
-                    operations.discard();
-                }
-                return operations.exec();
-            }
-        });
+    public Long save(Long shopId, Long waitingId) {
+        redisTemplate.opsForList().leftPush("s" + shopId, waitingId.toString());
+        return findRank(shopId, waitingId);
     }
 
     public List<Long> getShopWaitingIdsInOrder(Long shopId) {
@@ -61,33 +46,18 @@ public class RedisWaitingLineRepository implements WaitingLineRepository {
     }
 
     public void cancel(Long shopId, Long waitingId) {
-        validateIfWaitingExists(shopId, waitingId);
+        validateIfWaitingExists(shopId, waitingId); //삭제할 웨이팅 존재하는지 확인
         redisTemplate.opsForList().remove("s" + shopId, 1, waitingId.toString());
     }
 
-    public void postpone(Long shopId, Long waitingId) {
+    public Long postpone(Long shopId, Long waitingId) {
         validateIfWaitingExists(shopId, waitingId);
         validateIfPostponeAvailable(shopId, waitingId);
-        String key = "s" + shopId;
-        if (Objects.equals(findRank(shopId, waitingId), getWaitingLineSize(shopId))) {
-            throw new BadRequestCustomException(ALREADY_END_LINE);
-        }
-        redisTemplate.execute(new SessionCallback<>() {
-            @Override
-            public <K, V> Object execute(RedisOperations<K, V> operations)
-                throws DataAccessException {
-                try {
-                    operations.multi();
 
-                    redisTemplate.opsForList().remove(key, 1, waitingId.toString());
-                    redisTemplate.opsForList().leftPush(key, waitingId.toString());
-                    return operations.exec();
-                } catch (Exception e) {
-                    operations.discard();
-                }
-                return null;
-            }
-        });
+        String key = "s" + shopId;
+        redisTemplate.opsForList().remove(key, 1, waitingId.toString());
+        redisTemplate.opsForList().leftPush(key, waitingId.toString());
+        return findRank(shopId, waitingId);
     }
 
     public Long findRank(Long shopId, Long waitingId) {
@@ -110,7 +80,7 @@ public class RedisWaitingLineRepository implements WaitingLineRepository {
         return redisTemplate.opsForList().size("s" + shopId);
     }
 
-    public void validateIfWaitingExists(Long shopId, Long waitingId) {
+    private void validateIfWaitingExists(Long shopId, Long waitingId) {
         Long index = redisTemplate.opsForList().indexOf("s" + shopId, waitingId.toString());
         if (index == null) {
             throw new NotFoundCustomException(WAITING_DOES_NOT_EXIST);
@@ -119,9 +89,7 @@ public class RedisWaitingLineRepository implements WaitingLineRepository {
 
     private void validateIfPostponeAvailable(Long shopId, Long waitingId) {
         if (Objects.equals(findRank(shopId, waitingId), getWaitingLineSize(shopId))) {
-            {
-                throw new BadRequestCustomException(ALREADY_END_LINE);
-            }
+            throw new BadRequestCustomException(ALREADY_END_LINE);
         }
     }
 

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/WaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/WaitingLineRepository.java
@@ -4,13 +4,13 @@ import java.util.List;
 
 public interface WaitingLineRepository {
 
-    void save(Long shopId, Long waitingId);
+    Long save(Long shopId, Long waitingId);
 
     Long entry(Long shopId);
 
     void cancel(Long shopId, Long waitingId);
 
-    void postpone(Long shopId, Long waitingId);
+    Long postpone(Long shopId, Long waitingId);
 
     Long findRank(Long shopId, Long waitingId);
 

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/WaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/WaitingLineRepository.java
@@ -14,7 +14,7 @@ public interface WaitingLineRepository {
 
     Long findRank(Long shopId, Long waitingId);
 
-    Long findRankThirdValue(Long shopId);
+    Long findThirdRankValue(Long shopId);
 
     Long getWaitingLineSize(Long shopId);
 

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/WaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/WaitingLineRepository.java
@@ -14,6 +14,8 @@ public interface WaitingLineRepository {
 
     Long findRank(Long shopId, Long waitingId);
 
+    Long findRankThirdValue(Long shopId);
+
     Long getWaitingLineSize(Long shopId);
 
     List<Long> getShopWaitingIdsInOrder(Long shopId);

--- a/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/WaitingLineRepository.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/repository/waitingline/WaitingLineRepository.java
@@ -14,7 +14,7 @@ public interface WaitingLineRepository {
 
     Long findRank(Long shopId, Long waitingId);
 
-    Long findThirdRankValue(Long shopId);
+    Long findRankValue(Long shopId, int rank);
 
     Long getWaitingLineSize(Long shopId);
 

--- a/src/main/java/com/prgrms/catchtable/waiting/service/MemberWaitingService.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/service/MemberWaitingService.java
@@ -112,7 +112,7 @@ public class MemberWaitingService {
     }
 
     @Transactional(readOnly = true)
-    public MemberWaitingHistoryListResponse getMemberWaitingHistory(Member member) {
+    public MemberWaitingHistoryListResponse getWaitingHistory(Member member) {
         List<Waiting> waitings = waitingRepository.findWaitingWithMemberAndShop(member);
         return toMemberWaitingListResponse(waitings);
     }

--- a/src/main/java/com/prgrms/catchtable/waiting/service/MemberWaitingService.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/service/MemberWaitingService.java
@@ -60,7 +60,7 @@ public class MemberWaitingService {
 
         Long rank = waitingLineRepository.save(shopId, waiting.getId());// 대기열 저장
 
-        notification.sendMessageAsCreated(member, owner,rank);
+        notification.sendMessageAsCreated(member, owner, rank);
 
         return toMemberWaitingResponse(savedWaiting, rank);
     }
@@ -69,13 +69,14 @@ public class MemberWaitingService {
     public MemberWaitingResponse postponeWaiting(Member member) {
         Waiting waiting = getWaitingEntityInProgress(member);
         Long shopId = waiting.getShop().getId();
-        Long previousRank = waitingLineRepository.findRank(shopId, waiting.getId()); // 미루기 전 rank 저장
+        Long previousRank = waitingLineRepository.findRank(shopId,
+            waiting.getId()); // 미루기 전 rank 저장
 
         waiting.decreasePostponeRemainingCount();
         Long rank = waitingLineRepository.postpone(shopId, waiting.getId());// 미룬 후 rank 저장
 
         notification.sendEntryMessageToOthers(shopId, previousRank);
-        notification.sendMessageAsPostponed(member,previousRank);
+        notification.sendMessageAsPostponed(member, previousRank);
 
         return toMemberWaitingResponse(waiting, rank);
     }

--- a/src/main/java/com/prgrms/catchtable/waiting/service/MemberWaitingService.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/service/MemberWaitingService.java
@@ -1,11 +1,9 @@
 package com.prgrms.catchtable.waiting.service;
 
 import static com.prgrms.catchtable.common.exception.ErrorCode.ALREADY_PROGRESS_WAITING_EXISTS;
+import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_OWNER;
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_PROGRESS_WAITING;
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_SHOP;
-import static com.prgrms.catchtable.common.notification.WaitingNotificationContent.CANCELED;
-import static com.prgrms.catchtable.common.notification.WaitingNotificationContent.REGISTERED;
-import static com.prgrms.catchtable.common.notification.WaitingNotificationContent.THIRD_RANK;
 import static com.prgrms.catchtable.waiting.domain.WaitingStatus.PROGRESS;
 import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toMemberWaitingListResponse;
 import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toMemberWaitingResponse;
@@ -14,11 +12,11 @@ import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toWaiting;
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
 import com.prgrms.catchtable.member.domain.Member;
-import com.prgrms.catchtable.notification.dto.request.SendMessageToMemberRequest;
+import com.prgrms.catchtable.owner.domain.Owner;
+import com.prgrms.catchtable.owner.repository.OwnerRepository;
 import com.prgrms.catchtable.shop.domain.Shop;
 import com.prgrms.catchtable.shop.repository.ShopRepository;
 import com.prgrms.catchtable.waiting.domain.Waiting;
-import com.prgrms.catchtable.waiting.domain.WaitingStatus;
 import com.prgrms.catchtable.waiting.dto.request.CreateWaitingRequest;
 import com.prgrms.catchtable.waiting.dto.response.MemberWaitingHistoryListResponse;
 import com.prgrms.catchtable.waiting.dto.response.MemberWaitingResponse;
@@ -29,7 +27,6 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,28 +41,27 @@ public class MemberWaitingService {
     private final WaitingRepository waitingRepository;
     private final ShopRepository shopRepository;
     private final WaitingLineRepository waitingLineRepository;
-    private final ApplicationEventPublisher publisher;
+    private final OwnerRepository ownerRepository;
+    private final WaitingNotification notification;
 
     @Transactional
     public MemberWaitingResponse createWaiting(Long shopId, Member member,
         CreateWaitingRequest request) {
-        // 연관 엔티티 조회
-        Shop shop = getShopEntity(shopId);
+        Shop shop = getShopEntity(shopId); // 연관 엔티티 조회
+        Owner owner = getOwnerEntity(shop);
 
-        // 기존 waiting이 있는지 검증
-        validateIfMemberWaitingExists(member);
+        validateIfMemberWaitingExists(member); // 기존 진행 중인 waiting이 있는지 검증
 
-        // 대기 번호 생성
         int waitingNumber = (waitingRepository.countByShopAndCreatedAtBetween(shop,
-            START_DATE_TIME, END_DATE_TIME)).intValue() + 1;
+            START_DATE_TIME, END_DATE_TIME)).intValue() + 1; // 대기 번호 생성
 
-        // waiting 저장
-        Waiting waiting = toWaiting(request, waitingNumber, member, shop);
+        Waiting waiting = toWaiting(request, waitingNumber, member, shop); //waiting 생성 후 저장
         Waiting savedWaiting = waitingRepository.save(waiting);
 
-        waitingLineRepository.save(shopId, waiting.getId());
+        waitingLineRepository.save(shopId, waiting.getId()); // 대기열 저장
+
         Long rank = waitingLineRepository.findRank(shopId, waiting.getId());
-        sendMessageToMember(member, PROGRESS, rank);
+        notification.sendMessageAsCreated(member, owner,rank);
 
         return toMemberWaitingResponse(savedWaiting, rank);
     }
@@ -73,15 +69,16 @@ public class MemberWaitingService {
     @Transactional
     public MemberWaitingResponse postponeWaiting(Member member) {
         Waiting waiting = getWaitingEntityInProgress(member);
-        Shop shop = waiting.getShop();
-        Long previousRank = waitingLineRepository.findRank(shop.getId(), waiting.getId());
+        Long shopId = waiting.getShop().getId();
+        Long previousRank = waitingLineRepository.findRank(shopId, waiting.getId()); // 미루기 전 rank 저장
 
         waiting.decreasePostponeRemainingCount();
-        waitingLineRepository.postpone(shop.getId(), waiting.getId());
-        Long rank = waitingLineRepository.findRank(shop.getId(), waiting.getId());
-        if (previousRank <= 3) {
-            sendMessageToThirdRankMember(shop.getId());
-        }
+        waitingLineRepository.postpone(shopId, waiting.getId());
+        Long rank = waitingLineRepository.findRank(shopId, waiting.getId()); // 미룬 후 rank 저장
+
+        notification.sendEntryMessageToOthers(shopId, previousRank);
+        notification.sendMessageAsPostponed(member,previousRank);
+
         return toMemberWaitingResponse(waiting, rank);
     }
 
@@ -89,15 +86,16 @@ public class MemberWaitingService {
     public MemberWaitingResponse cancelWaiting(Member member) {
         Waiting waiting = getWaitingEntityInProgress(member);
         Shop shop = waiting.getShop();
+        Owner owner = getOwnerEntity(shop);
+
         Long previousRank = waitingLineRepository.findRank(shop.getId(), waiting.getId());
 
         waitingLineRepository.cancel(shop.getId(), waiting.getId());
         waiting.changeStatusCanceled();
 
-        sendMessageToMember(member, WaitingStatus.CANCELED, -1L);
-        if (previousRank <= 3) {
-            sendMessageToThirdRankMember(shop.getId());
-        }
+        notification.sendEntryMessageToOthers(shop.getId(), previousRank);
+        notification.sendMessageAsCanceled(member, owner, previousRank);
+
         return toMemberWaitingResponse(waiting, -1L);
     }
 
@@ -117,33 +115,6 @@ public class MemberWaitingService {
         return toMemberWaitingListResponse(waitings);
     }
 
-    public void sendMessageToThirdRankMember(Long shopId) {
-        Long thirdRankWaitingId = waitingLineRepository.findThirdRankValue(shopId);
-        if (thirdRankWaitingId != null) {
-            Member thirdRankMember = waitingRepository.findWaitingWithMember(thirdRankWaitingId)
-                .getMember();
-            SendMessageToMemberRequest request = SendMessageToMemberRequest.builder()
-                .member(thirdRankMember)
-                .content(THIRD_RANK.getMessage())
-                .build();
-            publisher.publishEvent(request);
-        }
-    }
-
-    public void sendMessageToMember(Member member, WaitingStatus status, Long rank) {
-        StringBuilder content = new StringBuilder();
-        if (status == PROGRESS) {
-            content.append(String.format(REGISTERED.getMessage(), rank));
-        } else {
-            content.append(CANCELED.getMessage());
-        }
-        SendMessageToMemberRequest request = SendMessageToMemberRequest.builder()
-            .member(member)
-            .content(content.toString())
-            .build();
-        publisher.publishEvent(request);
-    }
-
     private void validateIfMemberWaitingExists(Member member) {
         if (waitingRepository.existsByMemberAndStatus(member, PROGRESS)) {
             throw new BadRequestCustomException(ALREADY_PROGRESS_WAITING_EXISTS);
@@ -156,6 +127,12 @@ public class MemberWaitingService {
         );
         shop.validateIfShopOpened(LocalTime.now());
         return shop;
+    }
+
+    public Owner getOwnerEntity(Shop shop) {
+        return ownerRepository.findOwnerByShop(shop).orElseThrow(
+            () -> new NotFoundCustomException(NOT_EXIST_OWNER)
+        );
     }
 
     public Waiting getWaitingEntityInProgress(Member member) {

--- a/src/main/java/com/prgrms/catchtable/waiting/service/MemberWaitingService.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/service/MemberWaitingService.java
@@ -59,8 +59,8 @@ public class MemberWaitingService {
         Waiting savedWaiting = waitingRepository.save(waiting);
 
         waitingLineRepository.save(shopId, waiting.getId()); // 대기열 저장
-
         Long rank = waitingLineRepository.findRank(shopId, waiting.getId());
+
         notification.sendMessageAsCreated(member, owner,rank);
 
         return toMemberWaitingResponse(savedWaiting, rank);
@@ -121,7 +121,7 @@ public class MemberWaitingService {
         }
     }
 
-    public Shop getShopEntity(Long shopId) {
+    private Shop getShopEntity(Long shopId) {
         Shop shop = shopRepository.findById(shopId).orElseThrow(
             () -> new NotFoundCustomException(NOT_EXIST_SHOP)
         );
@@ -129,13 +129,13 @@ public class MemberWaitingService {
         return shop;
     }
 
-    public Owner getOwnerEntity(Shop shop) {
+    private Owner getOwnerEntity(Shop shop) {
         return ownerRepository.findOwnerByShop(shop).orElseThrow(
             () -> new NotFoundCustomException(NOT_EXIST_OWNER)
         );
     }
 
-    public Waiting getWaitingEntityInProgress(Member member) {
+    private Waiting getWaitingEntityInProgress(Member member) {
         return waitingRepository.findByMemberAndStatusWithShop(member, PROGRESS)
             .orElseThrow(() -> new NotFoundCustomException(NOT_EXIST_PROGRESS_WAITING));
     }

--- a/src/main/java/com/prgrms/catchtable/waiting/service/MemberWaitingService.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/service/MemberWaitingService.java
@@ -3,6 +3,9 @@ package com.prgrms.catchtable.waiting.service;
 import static com.prgrms.catchtable.common.exception.ErrorCode.EXISTING_MEMBER_WAITING;
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_PROGRESS_WAITING;
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_SHOP;
+import static com.prgrms.catchtable.common.notification.WaitingNotificationContent.CANCELED;
+import static com.prgrms.catchtable.common.notification.WaitingNotificationContent.REGISTERED;
+import static com.prgrms.catchtable.common.notification.WaitingNotificationContent.THIRD_RANK;
 import static com.prgrms.catchtable.waiting.domain.WaitingStatus.PROGRESS;
 import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toMemberWaitingListResponse;
 import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toMemberWaitingResponse;
@@ -120,22 +123,22 @@ public class MemberWaitingService {
                 .getMember();
             SendMessageToMemberRequest request = SendMessageToMemberRequest.builder()
                 .member(thirdRankMember)
-                .content("3번째 순서로 곧 입장하실 차례입니다.")
+                .content(THIRD_RANK.getMessage())
                 .build();
             publisher.publishEvent(request);
         }
     }
 
     public void sendMessageToMember(Member member, WaitingStatus status, Long rank) {
-        String content;
+        StringBuilder content = new StringBuilder();
         if (status == PROGRESS) {
-            content = String.format("웨이팅이 등록되었습니다. %d번째 순서입니다.", rank);
+            content.append(String.format(REGISTERED.getMessage(), rank));
         } else {
-            content = "웨이팅이 취소되었습니다.";
+            content.append(CANCELED.getMessage());
         }
         SendMessageToMemberRequest request = SendMessageToMemberRequest.builder()
             .member(member)
-            .content(content)
+            .content(content.toString())
             .build();
         publisher.publishEvent(request);
     }

--- a/src/main/java/com/prgrms/catchtable/waiting/service/MemberWaitingService.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/service/MemberWaitingService.java
@@ -58,8 +58,7 @@ public class MemberWaitingService {
         Waiting waiting = toWaiting(request, waitingNumber, member, shop); //waiting 생성 후 저장
         Waiting savedWaiting = waitingRepository.save(waiting);
 
-        waitingLineRepository.save(shopId, waiting.getId()); // 대기열 저장
-        Long rank = waitingLineRepository.findRank(shopId, waiting.getId());
+        Long rank = waitingLineRepository.save(shopId, waiting.getId());// 대기열 저장
 
         notification.sendMessageAsCreated(member, owner,rank);
 
@@ -73,8 +72,7 @@ public class MemberWaitingService {
         Long previousRank = waitingLineRepository.findRank(shopId, waiting.getId()); // 미루기 전 rank 저장
 
         waiting.decreasePostponeRemainingCount();
-        waitingLineRepository.postpone(shopId, waiting.getId());
-        Long rank = waitingLineRepository.findRank(shopId, waiting.getId()); // 미룬 후 rank 저장
+        Long rank = waitingLineRepository.postpone(shopId, waiting.getId());// 미룬 후 rank 저장
 
         notification.sendEntryMessageToOthers(shopId, previousRank);
         notification.sendMessageAsPostponed(member,previousRank);

--- a/src/main/java/com/prgrms/catchtable/waiting/service/MemberWaitingService.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/service/MemberWaitingService.java
@@ -76,7 +76,7 @@ public class MemberWaitingService {
         Long rank = waitingLineRepository.postpone(shopId, waiting.getId());// 미룬 후 rank 저장
 
         notification.sendEntryMessageToOthers(shopId, previousRank);
-        notification.sendMessageAsPostponed(member, previousRank);
+        notification.sendMessageAsPostponed(member, rank);
 
         return toMemberWaitingResponse(waiting, rank);
     }

--- a/src/main/java/com/prgrms/catchtable/waiting/service/MemberWaitingService.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/service/MemberWaitingService.java
@@ -1,12 +1,11 @@
 package com.prgrms.catchtable.waiting.service;
 
-import static com.prgrms.catchtable.common.exception.ErrorCode.EXISTING_MEMBER_WAITING;
+import static com.prgrms.catchtable.common.exception.ErrorCode.ALREADY_PROGRESS_WAITING_EXISTS;
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_PROGRESS_WAITING;
 import static com.prgrms.catchtable.common.exception.ErrorCode.NOT_EXIST_SHOP;
 import static com.prgrms.catchtable.common.notification.WaitingNotificationContent.CANCELED;
 import static com.prgrms.catchtable.common.notification.WaitingNotificationContent.REGISTERED;
 import static com.prgrms.catchtable.common.notification.WaitingNotificationContent.THIRD_RANK;
-import static com.prgrms.catchtable.waiting.domain.WaitingStatus.*;
 import static com.prgrms.catchtable.waiting.domain.WaitingStatus.PROGRESS;
 import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toMemberWaitingListResponse;
 import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toMemberWaitingResponse;
@@ -15,7 +14,6 @@ import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toWaiting;
 import com.prgrms.catchtable.common.exception.custom.BadRequestCustomException;
 import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
 import com.prgrms.catchtable.member.domain.Member;
-import com.prgrms.catchtable.member.repository.MemberRepository;
 import com.prgrms.catchtable.notification.dto.request.SendMessageToMemberRequest;
 import com.prgrms.catchtable.shop.domain.Shop;
 import com.prgrms.catchtable.shop.repository.ShopRepository;
@@ -146,8 +144,8 @@ public class MemberWaitingService {
     }
 
     private void validateIfMemberWaitingExists(Member member) {
-        if (waitingRepository.existsByMember(member)) {
-            throw new BadRequestCustomException(EXISTING_MEMBER_WAITING);
+        if (waitingRepository.existsByMemberAndStatus(member, PROGRESS)) {
+            throw new BadRequestCustomException(ALREADY_PROGRESS_WAITING_EXISTS);
         }
     }
 

--- a/src/main/java/com/prgrms/catchtable/waiting/service/MemberWaitingService.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/service/MemberWaitingService.java
@@ -45,6 +45,7 @@ public class MemberWaitingService {
     private final ShopRepository shopRepository;
     private final WaitingLineRepository waitingLineRepository;
     private final ApplicationEventPublisher publisher;
+
     @Transactional
     public MemberWaitingResponse createWaiting(Long shopId, Member member,
         CreateWaitingRequest request) {

--- a/src/main/java/com/prgrms/catchtable/waiting/service/OwnerWaitingService.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/service/OwnerWaitingService.java
@@ -7,7 +7,6 @@ import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toOwnerWaitingResp
 import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
 import com.prgrms.catchtable.owner.domain.Owner;
 import com.prgrms.catchtable.waiting.domain.Waiting;
-import com.prgrms.catchtable.waiting.dto.response.MemberWaitingResponse;
 import com.prgrms.catchtable.waiting.dto.response.OwnerWaitingListResponse;
 import com.prgrms.catchtable.waiting.dto.response.OwnerWaitingResponse;
 import com.prgrms.catchtable.waiting.repository.WaitingRepository;

--- a/src/main/java/com/prgrms/catchtable/waiting/service/OwnerWaitingService.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/service/OwnerWaitingService.java
@@ -1,7 +1,6 @@
 package com.prgrms.catchtable.waiting.service;
 
 import static com.prgrms.catchtable.common.exception.ErrorCode.WAITING_DOES_NOT_EXIST;
-import static com.prgrms.catchtable.common.notification.WaitingNotificationContent.*;
 import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toOwnerWaitingListResponse;
 import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toOwnerWaitingResponse;
 
@@ -41,12 +40,12 @@ public class OwnerWaitingService {
         waiting.changeStatusCompleted();
 
         waitingNotification.sendMessageAsCompleted(waiting.getMember());
-        waitingNotification.sendEntryMessageToOthers(shopId,1L);
+        waitingNotification.sendEntryMessageToOthers(shopId, 1L);
 
         return toOwnerWaitingResponse(waiting, 0L);
     }
 
-    private Waiting getWaitingEntity(Long waitingId){
+    private Waiting getWaitingEntity(Long waitingId) {
         return waitingRepository.findById(waitingId)
             .orElseThrow(() -> new NotFoundCustomException(WAITING_DOES_NOT_EXIST));
     }

--- a/src/main/java/com/prgrms/catchtable/waiting/service/OwnerWaitingService.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/service/OwnerWaitingService.java
@@ -7,6 +7,7 @@ import static com.prgrms.catchtable.waiting.dto.WaitingMapper.toOwnerWaitingResp
 import com.prgrms.catchtable.common.exception.custom.NotFoundCustomException;
 import com.prgrms.catchtable.owner.domain.Owner;
 import com.prgrms.catchtable.waiting.domain.Waiting;
+import com.prgrms.catchtable.waiting.dto.response.MemberWaitingResponse;
 import com.prgrms.catchtable.waiting.dto.response.OwnerWaitingListResponse;
 import com.prgrms.catchtable.waiting.dto.response.OwnerWaitingResponse;
 import com.prgrms.catchtable.waiting.repository.WaitingRepository;
@@ -22,6 +23,7 @@ public class OwnerWaitingService {
 
     private final WaitingRepository waitingRepository;
     private final WaitingLineRepository waitingLineRepository;
+    private final MemberWaitingService memberWaitingService;
 
     @Transactional(readOnly = true)
     public OwnerWaitingListResponse getShopAllWaiting(Owner owner) {
@@ -33,10 +35,12 @@ public class OwnerWaitingService {
 
     @Transactional
     public OwnerWaitingResponse entryWaiting(Owner owner) {
-        Long enteredWaitingId = waitingLineRepository.entry(owner.getShop().getId());
+        Long shopId = owner.getShop().getId();
+        Long enteredWaitingId = waitingLineRepository.entry(shopId);
         Waiting waiting = waitingRepository.findById(enteredWaitingId)
             .orElseThrow(() -> new NotFoundCustomException(WAITING_DOES_NOT_EXIST));
         waiting.changeStatusCompleted();
+        memberWaitingService.sendMessageToThirdRankMember(shopId);
         return toOwnerWaitingResponse(waiting, 0L);
     }
 }

--- a/src/main/java/com/prgrms/catchtable/waiting/service/WaitingNotification.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/service/WaitingNotification.java
@@ -1,0 +1,81 @@
+package com.prgrms.catchtable.waiting.service;
+
+import static com.prgrms.catchtable.common.notification.WaitingNotificationContent.FIRST_RANK;
+import static com.prgrms.catchtable.common.notification.WaitingNotificationContent.MEMBER_CANCELED;
+import static com.prgrms.catchtable.common.notification.WaitingNotificationContent.MEMBER_COMPLETED;
+import static com.prgrms.catchtable.common.notification.WaitingNotificationContent.MEMBER_CREATED;
+import static com.prgrms.catchtable.common.notification.WaitingNotificationContent.MEMBER_POSTPONED;
+import static com.prgrms.catchtable.common.notification.WaitingNotificationContent.OWNER_CANCELED;
+import static com.prgrms.catchtable.common.notification.WaitingNotificationContent.OWNER_CREATED;
+import static com.prgrms.catchtable.common.notification.WaitingNotificationContent.THIRD_RANK;
+
+import com.prgrms.catchtable.common.notification.WaitingNotificationContent;
+import com.prgrms.catchtable.member.domain.Member;
+import com.prgrms.catchtable.notification.dto.request.SendMessageToMemberRequest;
+import com.prgrms.catchtable.notification.dto.request.SendMessageToOwnerRequest;
+import com.prgrms.catchtable.owner.domain.Owner;
+import com.prgrms.catchtable.waiting.repository.WaitingRepository;
+import com.prgrms.catchtable.waiting.repository.waitingline.WaitingLineRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class WaitingNotification {
+    private final ApplicationEventPublisher publisher;
+    private final WaitingLineRepository waitingLineRepository;
+    private final WaitingRepository waitingRepository;
+
+    public void sendMessageAsCreated(Member member, Owner owner, Long rank) {
+        sendMessageToMember(member, String.format(MEMBER_CREATED.getContent(), rank));
+        sendMessageToOwner(owner, String.format(OWNER_CREATED.getContent(), rank));
+    }
+
+    public void sendMessageAsPostponed(Member member, Long rank) {
+        sendMessageToMember(member, String.format(MEMBER_POSTPONED.getContent(), rank));
+    }
+
+    public void sendMessageAsCompleted(Member member) {
+        sendMessageToMember(member, MEMBER_COMPLETED.getContent());
+    }
+
+    public void sendMessageAsCanceled(Member member, Owner owner, Long rank) {
+        sendMessageToMember(member,MEMBER_CANCELED.getContent());
+        sendMessageToOwner(owner, String.format(OWNER_CANCELED.getContent(), rank));
+    }
+
+    public void sendEntryMessageToOthers(Long shopId, Long removedMemberRank) {
+        if (removedMemberRank <= 3) { // 대기열에서 rank 3이하 회원이 사라지면
+            sendEntryMessageToOthers(shopId, 3, THIRD_RANK); // 세 번째 회원에게 알림
+        }
+        if (removedMemberRank == 1) { //대기열에서 rank 1 회원이 사라지면
+            sendEntryMessageToOthers(shopId, 1, FIRST_RANK); // 첫 번째 회원에게 알림
+        }
+    }
+
+    private void sendEntryMessageToOthers(Long shopId, int rank,
+        WaitingNotificationContent content) {
+        Long waitingId = waitingLineRepository.findRankValue(shopId, rank); // rank로 waitingId 찾기
+        if (waitingId != null) {
+            Member member = waitingRepository.findWaitingWithMember(waitingId).getMember();
+            sendMessageToMember(member, content.getContent());
+        }
+    }
+
+    private void sendMessageToMember(Member member, String content) {
+        SendMessageToMemberRequest request = SendMessageToMemberRequest.builder()
+            .member(member)
+            .content(content)
+            .build();
+        publisher.publishEvent(request);
+    }
+
+    private void sendMessageToOwner(Owner owner, String content) {
+        SendMessageToOwnerRequest request = SendMessageToOwnerRequest.builder()
+            .owner(owner)
+            .content(content)
+            .build();
+        publisher.publishEvent(request);
+    }
+}

--- a/src/main/java/com/prgrms/catchtable/waiting/service/WaitingNotification.java
+++ b/src/main/java/com/prgrms/catchtable/waiting/service/WaitingNotification.java
@@ -23,6 +23,7 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class WaitingNotification {
+
     private final ApplicationEventPublisher publisher;
     private final WaitingLineRepository waitingLineRepository;
     private final WaitingRepository waitingRepository;
@@ -41,7 +42,7 @@ public class WaitingNotification {
     }
 
     public void sendMessageAsCanceled(Member member, Owner owner, Long rank) {
-        sendMessageToMember(member,MEMBER_CANCELED.getContent());
+        sendMessageToMember(member, MEMBER_CANCELED.getContent());
         sendMessageToOwner(owner, String.format(OWNER_CANCELED.getContent(), rank));
     }
 

--- a/src/test/java/com/prgrms/catchtable/waiting/controller/MemberWaitingControllerDocsTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/controller/MemberWaitingControllerDocsTest.java
@@ -212,9 +212,9 @@ class MemberWaitingControllerDocsTest extends RestDocsSupport {
         MemberWaitingHistoryListResponse responses = MemberWaitingHistoryListResponse.builder()
             .memberWaitings(List.of(response1, response2))
             .build();
-        given(memberWaitingService.getMemberWaitingHistory(member)).willReturn(responses);
+        given(memberWaitingService.getWaitingHistory(member)).willReturn(responses);
         //when, then
-        mockMvc.perform(get("/waitings/all")
+        mockMvc.perform(get("/waitings/history")
                 .contentType(APPLICATION_JSON)
                 .headers(getHttpHeaders(member)))
             .andExpect(status().isOk())

--- a/src/test/java/com/prgrms/catchtable/waiting/controller/MemberWaitingControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/controller/MemberWaitingControllerTest.java
@@ -22,6 +22,9 @@ import com.prgrms.catchtable.jwt.token.Token;
 import com.prgrms.catchtable.member.MemberFixture;
 import com.prgrms.catchtable.member.domain.Member;
 import com.prgrms.catchtable.member.repository.MemberRepository;
+import com.prgrms.catchtable.owner.domain.Owner;
+import com.prgrms.catchtable.owner.fixture.OwnerFixture;
+import com.prgrms.catchtable.owner.repository.OwnerRepository;
 import com.prgrms.catchtable.shop.domain.Shop;
 import com.prgrms.catchtable.shop.fixture.ShopFixture;
 import com.prgrms.catchtable.shop.repository.ShopRepository;
@@ -48,19 +51,19 @@ class MemberWaitingControllerTest extends BaseIntegrationTest {
     @Autowired
     private MemberRepository memberRepository;
     @Autowired
+    private OwnerRepository ownerRepository;
+    @Autowired
     private WaitingRepository waitingRepository;
-
     @Autowired
     private WaitingLineRepository waitingLineRepository;
     @Autowired
     private ShopRepository shopRepository;
+    @Autowired
+    private StringRedisTemplate redisTemplate;
     private Member member1, member2, member3;
     private Shop shop;
     private Waiting waiting1, waiting2, waiting3;
     private List<Waiting> waitings;
-
-    @Autowired
-    private StringRedisTemplate redisTemplate;
 
     @BeforeEach
     void setUp() {
@@ -71,6 +74,11 @@ class MemberWaitingControllerTest extends BaseIntegrationTest {
 
         shop = ShopFixture.shopWith24();
         shopRepository.save(shop);
+
+        Owner owner = OwnerFixture.getOwner("owner@naver.com", "owner");
+        owner.insertShop(shop);
+        ownerRepository.save(owner);
+
         waiting1 = Waiting.builder()
             .member(member1)
             .shop(shop)
@@ -270,8 +278,7 @@ class MemberWaitingControllerTest extends BaseIntegrationTest {
             .andExpect(jsonPath("$.memberWaitings[1].status").value(CANCELED.getDescription()))
             .andExpect(jsonPath("$.memberWaitings[2].waitingId").value(completedWaiting.getId()))
             .andExpect(jsonPath("$.memberWaitings[2].status").value(COMPLETED.getDescription()))
-            .andDo(MockMvcResultHandlers.print())
-        ;
+            .andDo(MockMvcResultHandlers.print());
     }
 
     private HttpHeaders getHttpHeaders(Member member) {

--- a/src/test/java/com/prgrms/catchtable/waiting/controller/MemberWaitingControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/controller/MemberWaitingControllerTest.java
@@ -235,7 +235,7 @@ class MemberWaitingControllerTest extends BaseIntegrationTest {
             () -> waitingLineRepository.findRank(shop.getId(), waiting1.getId()));
     }
 
-    @DisplayName("웨이팅 조회 API를 호출할 수 있다.")
+    @DisplayName("진행 중인 웨이팅 조회 API를 호출할 수 있다.")
     @Test
     void getWaiting() throws Exception {
         //when, then
@@ -259,7 +259,7 @@ class MemberWaitingControllerTest extends BaseIntegrationTest {
         Waiting canceledWaiting = WaitingFixture.canceledWaiting(member1, shop, 23);
         Waiting completedWaiting = WaitingFixture.completedWaiting(member1, shop, 233);
         waitingRepository.saveAll(List.of(canceledWaiting, completedWaiting));
-        mockMvc.perform(get("/waitings/all")
+        mockMvc.perform(get("/waitings/history")
                 .contentType(APPLICATION_JSON)
                 .headers(getHttpHeaders(member1)))
             .andExpect(status().isOk())

--- a/src/test/java/com/prgrms/catchtable/waiting/controller/MemberWaitingControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/controller/MemberWaitingControllerTest.java
@@ -1,7 +1,6 @@
 package com.prgrms.catchtable.waiting.controller;
 
 import static com.prgrms.catchtable.common.Role.MEMBER;
-import static com.prgrms.catchtable.common.exception.ErrorCode.ALREADY_OCCUPIED_RESERVATION_TIME;
 import static com.prgrms.catchtable.common.exception.ErrorCode.ALREADY_PROGRESS_WAITING_EXISTS;
 import static com.prgrms.catchtable.waiting.domain.WaitingStatus.CANCELED;
 import static com.prgrms.catchtable.waiting.domain.WaitingStatus.COMPLETED;
@@ -113,7 +112,6 @@ class MemberWaitingControllerTest extends BaseIntegrationTest {
         CreateWaitingRequest request = WaitingFixture.createWaitingRequest();
         Member member4 = MemberFixture.member("test4@naver.com");
         memberRepository.save(member4);
-
 
         // when, then
         mockMvc.perform(post("/waitings/{shopId}", shop.getId())

--- a/src/test/java/com/prgrms/catchtable/waiting/controller/OwnerWaitingControllerDocsTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/controller/OwnerWaitingControllerDocsTest.java
@@ -1,6 +1,7 @@
 package com.prgrms.catchtable.waiting.controller;
 
-import static com.prgrms.catchtable.waiting.domain.WaitingStatus.*;
+import static com.prgrms.catchtable.waiting.domain.WaitingStatus.COMPLETED;
+import static com.prgrms.catchtable.waiting.domain.WaitingStatus.PROGRESS;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
@@ -15,7 +16,6 @@ import com.prgrms.catchtable.common.restdocs.RestDocsSupport;
 import com.prgrms.catchtable.owner.domain.Owner;
 import com.prgrms.catchtable.owner.fixture.OwnerFixture;
 import com.prgrms.catchtable.owner.repository.OwnerRepository;
-import com.prgrms.catchtable.waiting.domain.WaitingStatus;
 import com.prgrms.catchtable.waiting.dto.response.OwnerWaitingListResponse;
 import com.prgrms.catchtable.waiting.dto.response.OwnerWaitingResponse;
 import com.prgrms.catchtable.waiting.service.OwnerWaitingService;

--- a/src/test/java/com/prgrms/catchtable/waiting/controller/OwnerWaitingControllerDocsTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/controller/OwnerWaitingControllerDocsTest.java
@@ -57,7 +57,7 @@ class OwnerWaitingControllerDocsTest extends RestDocsSupport {
             .build();
         given(ownerWaitingService.entryWaiting(owner)).willReturn(response);
         //when, then
-        mockMvc.perform(patch("/owner/waitings")
+        mockMvc.perform(patch("/owners/waitings")
                 .contentType(APPLICATION_JSON)
                 .headers(getHttpHeaders(owner)))
             .andExpect(status().isOk())
@@ -103,7 +103,7 @@ class OwnerWaitingControllerDocsTest extends RestDocsSupport {
         given(ownerWaitingService.getShopAllWaiting(owner)).willReturn(responses);
 
         //when, then
-        mockMvc.perform(get("/owner/waitings")
+        mockMvc.perform(get("/owners/waitings")
                 .contentType(APPLICATION_JSON)
                 .headers(getHttpHeaders(owner)))
             .andExpect(status().isOk())

--- a/src/test/java/com/prgrms/catchtable/waiting/controller/OwnerWaitingControllerDocsTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/controller/OwnerWaitingControllerDocsTest.java
@@ -1,5 +1,6 @@
 package com.prgrms.catchtable.waiting.controller;
 
+import static com.prgrms.catchtable.waiting.domain.WaitingStatus.*;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
@@ -14,6 +15,7 @@ import com.prgrms.catchtable.common.restdocs.RestDocsSupport;
 import com.prgrms.catchtable.owner.domain.Owner;
 import com.prgrms.catchtable.owner.fixture.OwnerFixture;
 import com.prgrms.catchtable.owner.repository.OwnerRepository;
+import com.prgrms.catchtable.waiting.domain.WaitingStatus;
 import com.prgrms.catchtable.waiting.dto.response.OwnerWaitingListResponse;
 import com.prgrms.catchtable.waiting.dto.response.OwnerWaitingResponse;
 import com.prgrms.catchtable.waiting.service.OwnerWaitingService;
@@ -49,9 +51,9 @@ class OwnerWaitingControllerDocsTest extends RestDocsSupport {
         OwnerWaitingResponse response = OwnerWaitingResponse.builder()
             .waitingId(1L)
             .waitingNumber(20)
-            .rank(1L)
+            .rank(0L)
             .peopleCount(2)
-            .status("진행 중")
+            .status(COMPLETED.getDescription())
             .build();
         given(ownerWaitingService.entryWaiting(owner)).willReturn(response);
         //when, then
@@ -85,14 +87,14 @@ class OwnerWaitingControllerDocsTest extends RestDocsSupport {
             .waitingNumber(20)
             .rank(1L)
             .peopleCount(2)
-            .status("진행 중")
+            .status(PROGRESS.getDescription())
             .build();
         OwnerWaitingResponse response2 = OwnerWaitingResponse.builder()
             .waitingId(2L)
             .waitingNumber(21)
             .rank(2L)
             .peopleCount(2)
-            .status("진행 중")
+            .status(PROGRESS.getDescription())
             .build();
         OwnerWaitingListResponse responses = OwnerWaitingListResponse.builder()
             .shopWaitings(List.of(response1, response2))

--- a/src/test/java/com/prgrms/catchtable/waiting/controller/OwnerWaitingControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/controller/OwnerWaitingControllerTest.java
@@ -109,7 +109,7 @@ class OwnerWaitingControllerTest extends BaseIntegrationTest {
     @Test
     void getWaiting() throws Exception {
         //when, then
-        mockMvc.perform(get("/owner/waitings")
+        mockMvc.perform(get("/owners/waitings")
                 .contentType(APPLICATION_JSON)
                 .headers(httpHeaders))
             .andExpect(status().isOk())
@@ -131,7 +131,7 @@ class OwnerWaitingControllerTest extends BaseIntegrationTest {
     @Test
     void entryWaiting() throws Exception {
         //when, then
-        mockMvc.perform(patch("/owner/waitings")
+        mockMvc.perform(patch("/owners/waitings")
                 .contentType(APPLICATION_JSON)
                 .headers(httpHeaders))
             .andExpect(status().isOk())

--- a/src/test/java/com/prgrms/catchtable/waiting/fixture/WaitingFixture.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/fixture/WaitingFixture.java
@@ -4,6 +4,7 @@ import com.prgrms.catchtable.member.domain.Member;
 import com.prgrms.catchtable.shop.domain.Shop;
 import com.prgrms.catchtable.waiting.domain.Waiting;
 import com.prgrms.catchtable.waiting.domain.WaitingStatus;
+import com.prgrms.catchtable.waiting.dto.request.CreateWaitingRequest;
 import com.prgrms.catchtable.waiting.dto.response.MemberWaitingResponse;
 
 public class WaitingFixture {
@@ -27,6 +28,12 @@ public class WaitingFixture {
         Waiting waiting = progressWaiting(member, shop, waitingNumber);
         waiting.changeStatusCanceled();
         return waiting;
+    }
+
+    public static CreateWaitingRequest createWaitingRequest(){
+        return CreateWaitingRequest
+            .builder()
+            .peopleCount(2).build();
     }
 
     public static MemberWaitingResponse memberWaitingResponse(int remainingPostponeCount,

--- a/src/test/java/com/prgrms/catchtable/waiting/fixture/WaitingFixture.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/fixture/WaitingFixture.java
@@ -30,7 +30,7 @@ public class WaitingFixture {
         return waiting;
     }
 
-    public static CreateWaitingRequest createWaitingRequest(){
+    public static CreateWaitingRequest createWaitingRequest() {
         return CreateWaitingRequest
             .builder()
             .peopleCount(2).build();

--- a/src/test/java/com/prgrms/catchtable/waiting/repository/WaitingRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/repository/WaitingRepositoryTest.java
@@ -106,7 +106,7 @@ class WaitingRepositoryTest {
 
     @DisplayName("특정 멤버의 웨이팅 목록을 조회할 수 있다.")
     @Test
-    void findWaitingWithMember() {
+    void findWaitingWithShopAndMember() {
         //given
         Waiting canceledWaiting = WaitingFixture.canceledWaiting(member1, shop, 1);
         Waiting completedWaiting = WaitingFixture.completedWaiting(member1, shop, 2);
@@ -114,7 +114,7 @@ class WaitingRepositoryTest {
 
         waitingRepository.saveAll(List.of(canceledWaiting, completedWaiting, progressWaiting));
         //when
-        List<Waiting> memberAllWaitings = waitingRepository.findWaitingWithMember(member1);
+        List<Waiting> memberAllWaitings = waitingRepository.findWaitingWithMemberAndShop(member1);
         //then
         assertThat(memberAllWaitings).containsExactly(canceledWaiting, completedWaiting,
             progressWaiting);

--- a/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/BasicWaitingLineRepositoryTest.java
@@ -130,4 +130,31 @@ class BasicWaitingLineRepositoryTest {
         assertThat(waitingIds.get(2)).isEqualTo(3L);
     }
 
+    @DisplayName("웨이팅 3번째 waitingId 반환한다.")
+    @Test
+    void findThirdRankValue() {
+        //given
+        Long shopId = 1L;
+        repository.save(shopId, 1L);
+        repository.save(shopId, 2L);
+        repository.save(shopId, 3L);
+        //when
+        Long waitingId = repository.findRankValue(shopId, 3);
+        //then
+        assertThat(waitingId).isEqualTo(3L);
+    }
+
+    @DisplayName("웨이팅 3번째 waitingId 없으면 null을 반환한다.")
+    @Test
+    void findThirdRankValueNull() {
+        //given
+        Long shopId = 1L;
+        repository.save(shopId, 1L);
+        repository.save(shopId, 2L);
+        //when
+        Long waitingId = repository.findRankValue(shopId, 3);
+        //then
+        assertThat(waitingId).isNull();
+    }
+
 }

--- a/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepositoryTest.java
@@ -148,27 +148,27 @@ class RedisWaitingLineRepositoryTest {
 
     @DisplayName("웨이팅 3번째 waitingId 반환")
     @Test
-    void findRankSecondValue() {
+    void findThirdRankValue() {
         //given
         Long shopId = 1L;
         repository.save(shopId, 1L);
         repository.save(shopId, 2L);
         repository.save(shopId, 3L);
         //when
-        Long waitingId = repository.findRankThirdValue(shopId);
+        Long waitingId = repository.findThirdRankValue(shopId);
         //then
         assertThat(waitingId).isEqualTo(3L);
     }
 
     @DisplayName("웨이팅 3번째 waitingId 없으면 null 반환")
     @Test
-    void findRankThirdValueNull() {
+    void findThirdRankValueNull() {
         //given
         Long shopId = 1L;
         repository.save(shopId, 1L);
         repository.save(shopId, 2L);
         //when
-        Long waitingId = repository.findRankThirdValue(shopId);
+        Long waitingId = repository.findThirdRankValue(shopId);
         //then
         assertThat(waitingId).isNull();
     }

--- a/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepositoryTest.java
@@ -146,7 +146,21 @@ class RedisWaitingLineRepositoryTest {
         assertThat(waitingLineSize).isZero();
     }
 
-    @DisplayName("웨이팅 3번째 waitingId 반환")
+    @DisplayName("웨이팅 1번째 waitingId 반환한다.")
+    @Test
+    void findThirdFirstValue() {
+        //given
+        Long shopId = 1L;
+        repository.save(shopId, 1L);
+        repository.save(shopId, 2L);
+        repository.save(shopId, 3L);
+        //when
+        Long waitingId = repository.findRankValue(shopId, 1);
+        //then
+        assertThat(waitingId).isEqualTo(1L);
+    }
+
+    @DisplayName("웨이팅 3번째 waitingId 반환한다.")
     @Test
     void findThirdRankValue() {
         //given
@@ -155,12 +169,12 @@ class RedisWaitingLineRepositoryTest {
         repository.save(shopId, 2L);
         repository.save(shopId, 3L);
         //when
-        Long waitingId = repository.findThirdRankValue(shopId);
+        Long waitingId = repository.findRankValue(shopId, 3);
         //then
         assertThat(waitingId).isEqualTo(3L);
     }
 
-    @DisplayName("웨이팅 3번째 waitingId 없으면 null 반환")
+    @DisplayName("웨이팅 3번째 waitingId 없으면 null을 반환한다.")
     @Test
     void findThirdRankValueNull() {
         //given
@@ -168,10 +182,8 @@ class RedisWaitingLineRepositoryTest {
         repository.save(shopId, 1L);
         repository.save(shopId, 2L);
         //when
-        Long waitingId = repository.findThirdRankValue(shopId);
+        Long waitingId = repository.findRankValue(shopId, 3);
         //then
         assertThat(waitingId).isNull();
     }
-
-
 }

--- a/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepositoryTest.java
@@ -74,13 +74,13 @@ class RedisWaitingLineRepositoryTest {
         repository.save(shopId, 3L);
 
         //when
-        repository.postpone(1L, 1L);
+        repository.postpone(1L, 2L);
 
         //then
         assertThat(repository.findRank(1L, 1L))
-            .isEqualTo(3);
-        assertThat(repository.findRank(1L, 2L))
             .isEqualTo(1);
+        assertThat(repository.findRank(1L, 2L))
+            .isEqualTo(3);
         assertThat(repository.findRank(1L, 3L))
             .isEqualTo(2);
 
@@ -172,4 +172,6 @@ class RedisWaitingLineRepositoryTest {
         //then
         assertThat(waitingId).isNull();
     }
+
+
 }

--- a/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/repository/waitingline/RedisWaitingLineRepositoryTest.java
@@ -145,4 +145,31 @@ class RedisWaitingLineRepositoryTest {
         //then
         assertThat(waitingLineSize).isZero();
     }
+
+    @DisplayName("웨이팅 3번째 waitingId 반환")
+    @Test
+    void findRankSecondValue() {
+        //given
+        Long shopId = 1L;
+        repository.save(shopId, 1L);
+        repository.save(shopId, 2L);
+        repository.save(shopId, 3L);
+        //when
+        Long waitingId = repository.findRankThirdValue(shopId);
+        //then
+        assertThat(waitingId).isEqualTo(3L);
+    }
+
+    @DisplayName("웨이팅 3번째 waitingId 없으면 null 반환")
+    @Test
+    void findRankThirdValueNull() {
+        //given
+        Long shopId = 1L;
+        repository.save(shopId, 1L);
+        repository.save(shopId, 2L);
+        //when
+        Long waitingId = repository.findRankThirdValue(shopId);
+        //then
+        assertThat(waitingId).isNull();
+    }
 }

--- a/src/test/java/com/prgrms/catchtable/waiting/service/MemberWaitingServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/service/MemberWaitingServiceTest.java
@@ -66,7 +66,7 @@ class MemberWaitingServiceTest {
         given(shopRepository.findById(1L)).willReturn(Optional.of(shop));
         given(shop.getId()).willReturn(1L);
 
-        given(waitingRepository.existsByMember(member)).willReturn(false);
+        given(waitingRepository.existsByMemberAndStatus(member,PROGRESS)).willReturn(false);
         given(waitingRepository.save(any(Waiting.class))).willReturn(waiting);
         given(waitingLineRepository.findRank(shop.getId(), waiting.getId())).willReturn(1L);
 

--- a/src/test/java/com/prgrms/catchtable/waiting/service/MemberWaitingServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/service/MemberWaitingServiceTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 class MemberWaitingServiceTest {
@@ -36,6 +37,9 @@ class MemberWaitingServiceTest {
     private WaitingRepository waitingRepository;
     @Mock
     private ShopRepository shopRepository;
+
+    @Mock
+    private ApplicationEventPublisher publisher;
 
     @Mock
     private WaitingLineRepository waitingLineRepository;
@@ -113,6 +117,7 @@ class MemberWaitingServiceTest {
             Optional.of(waiting));
         given(waiting.getShop()).willReturn(shop);
         given(waiting.getStatus()).willReturn(CANCELED);
+        given(waitingRepository.findWaitingWithMember(anyLong())).willReturn(waiting);
         doNothing().when(waiting).changeStatusCanceled();
 
         //when
@@ -157,7 +162,7 @@ class MemberWaitingServiceTest {
         Shop shop = mock(Shop.class);
         Waiting waiting = mock(Waiting.class);
 
-        given(waitingRepository.findWaitingWithMember(member)).willReturn(
+        given(waitingRepository.findWaitingWithMemberAndShop(member)).willReturn(
             List.of(waiting));
         given(waiting.getShop()).willReturn(shop);
         given(waiting.getStatus()).willReturn(CANCELED);

--- a/src/test/java/com/prgrms/catchtable/waiting/service/MemberWaitingServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/service/MemberWaitingServiceTest.java
@@ -66,7 +66,7 @@ class MemberWaitingServiceTest {
         given(shopRepository.findById(1L)).willReturn(Optional.of(shop));
         given(shop.getId()).willReturn(1L);
 
-        given(waitingRepository.existsByMemberAndStatus(member,PROGRESS)).willReturn(false);
+        given(waitingRepository.existsByMemberAndStatus(member, PROGRESS)).willReturn(false);
         given(waitingRepository.save(any(Waiting.class))).willReturn(waiting);
         given(waitingLineRepository.findRank(shop.getId(), waiting.getId())).willReturn(1L);
 

--- a/src/test/java/com/prgrms/catchtable/waiting/service/MemberWaitingServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/service/MemberWaitingServiceTest.java
@@ -11,6 +11,8 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 
 import com.prgrms.catchtable.member.domain.Member;
+import com.prgrms.catchtable.owner.domain.Owner;
+import com.prgrms.catchtable.owner.repository.OwnerRepository;
 import com.prgrms.catchtable.shop.domain.Shop;
 import com.prgrms.catchtable.shop.repository.ShopRepository;
 import com.prgrms.catchtable.waiting.domain.Waiting;
@@ -34,13 +36,14 @@ import org.springframework.context.ApplicationEventPublisher;
 class MemberWaitingServiceTest {
 
     @Mock
+    WaitingNotification waitingNotification;
+
+    @Mock
+    private OwnerRepository ownerRepository;
+    @Mock
     private WaitingRepository waitingRepository;
     @Mock
     private ShopRepository shopRepository;
-
-    @Mock
-    private ApplicationEventPublisher publisher;
-
     @Mock
     private WaitingLineRepository waitingLineRepository;
     @InjectMocks
@@ -55,17 +58,17 @@ class MemberWaitingServiceTest {
             .build();
         Shop shop = mock(Shop.class);
         Member member = mock(Member.class);
+        Owner owner = mock(Owner.class);
         Waiting waiting = Waiting.builder()
             .member(member)
             .shop(shop)
             .waitingNumber(1)
             .peopleCount(2)
             .build();
-
+        given(ownerRepository.findOwnerByShop(shop)).willReturn(Optional.of(owner));
         doNothing().when(shop).validateIfShopOpened(any(LocalTime.class));
         given(shopRepository.findById(1L)).willReturn(Optional.of(shop));
         given(shop.getId()).willReturn(1L);
-
         given(waitingRepository.existsByMemberAndStatus(member, PROGRESS)).willReturn(false);
         given(waitingRepository.save(any(Waiting.class))).willReturn(waiting);
         given(waitingLineRepository.findRank(shop.getId(), waiting.getId())).willReturn(1L);
@@ -90,7 +93,6 @@ class MemberWaitingServiceTest {
 
         given(waitingRepository.findByMemberAndStatusWithShop(member, PROGRESS)).willReturn(
             Optional.of(waiting));
-        given(waitingRepository.findWaitingWithMember(anyLong())).willReturn(waiting);
         given(waiting.getShop()).willReturn(shop);
         given(waiting.getStatus()).willReturn(PROGRESS);
         given(waitingLineRepository.findRank(anyLong(), anyLong())).willReturn(3L);
@@ -113,12 +115,13 @@ class MemberWaitingServiceTest {
         Shop shop = mock(Shop.class);
         Member member = mock(Member.class);
         Waiting waiting = mock(Waiting.class);
+        Owner owner = mock(Owner.class);
 
         given(waitingRepository.findByMemberAndStatusWithShop(member, PROGRESS)).willReturn(
             Optional.of(waiting));
+        given(ownerRepository.findOwnerByShop(shop)).willReturn(Optional.of(owner));
         given(waiting.getShop()).willReturn(shop);
         given(waiting.getStatus()).willReturn(CANCELED);
-        given(waitingRepository.findWaitingWithMember(anyLong())).willReturn(waiting);
         doNothing().when(waiting).changeStatusCanceled();
 
         //when

--- a/src/test/java/com/prgrms/catchtable/waiting/service/MemberWaitingServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/service/MemberWaitingServiceTest.java
@@ -71,7 +71,7 @@ class MemberWaitingServiceTest {
         given(shop.getId()).willReturn(1L);
         given(waitingRepository.existsByMemberAndStatus(member, PROGRESS)).willReturn(false);
         given(waitingRepository.save(any(Waiting.class))).willReturn(waiting);
-        given(waitingLineRepository.findRank(shop.getId(), waiting.getId())).willReturn(1L);
+        given(waitingLineRepository.save(shop.getId(), waiting.getId())).willReturn(1L);
 
         //when
         MemberWaitingResponse response = memberWaitingService.createWaiting(1L, member, request);

--- a/src/test/java/com/prgrms/catchtable/waiting/service/MemberWaitingServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/service/MemberWaitingServiceTest.java
@@ -169,7 +169,7 @@ class MemberWaitingServiceTest {
         given(waiting.getStatus()).willReturn(CANCELED);
 
         //when
-        MemberWaitingHistoryListResponse response = memberWaitingService.getMemberWaitingHistory(
+        MemberWaitingHistoryListResponse response = memberWaitingService.getWaitingHistory(
             member);
 
         //then

--- a/src/test/java/com/prgrms/catchtable/waiting/service/MemberWaitingServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/service/MemberWaitingServiceTest.java
@@ -90,6 +90,7 @@ class MemberWaitingServiceTest {
 
         given(waitingRepository.findByMemberAndStatusWithShop(member, PROGRESS)).willReturn(
             Optional.of(waiting));
+        given(waitingRepository.findWaitingWithMember(anyLong())).willReturn(waiting);
         given(waiting.getShop()).willReturn(shop);
         given(waiting.getStatus()).willReturn(PROGRESS);
         given(waitingLineRepository.findRank(anyLong(), anyLong())).willReturn(3L);

--- a/src/test/java/com/prgrms/catchtable/waiting/service/MemberWaitingServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/service/MemberWaitingServiceTest.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 class MemberWaitingServiceTest {

--- a/src/test/java/com/prgrms/catchtable/waiting/service/OwnerWaitingServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/service/OwnerWaitingServiceTest.java
@@ -32,7 +32,7 @@ class OwnerWaitingServiceTest {
     private OwnerRepository ownerRepository;
 
     @Mock
-    private MemberWaitingService memberWaitingService;
+    private WaitingNotification waitingNotification;
 
     @Mock
     private WaitingRepository waitingRepository;

--- a/src/test/java/com/prgrms/catchtable/waiting/service/OwnerWaitingServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/waiting/service/OwnerWaitingServiceTest.java
@@ -32,6 +32,9 @@ class OwnerWaitingServiceTest {
     private OwnerRepository ownerRepository;
 
     @Mock
+    private MemberWaitingService memberWaitingService;
+
+    @Mock
     private WaitingRepository waitingRepository;
 
     @Mock


### PR DESCRIPTION
- close #102 
### ⛏ 작업 상세 내용
- 웨이팅 알림 구현
  - `WaitingNotificationContent` Enum 추가
  - 서비스 알림 보내는 메서드들 추가
  - `redisWaitingLineRepository`에 세 번째 순서 웨이팅 아이디 반환 함수 추가
- redis 대기열 로직 수정
  - 대기열 지연 시 해당 멤버가 미뤄지는게 아니라 맨 앞의 멤버가 미뤄져서 수정
  - 트랜잭션 처리 불필요한 로직들 session 내에서 실행하지 않도록 함
  - `redisWaitingLineRepository` 테스트 코드 수정
- 웨이팅 생성 시 validate 로직 수정
  - 한 멤버에 대한 웨이팅 여러 건 존재하므로, 단순 웨이팅이 있는지가 아니라 진행 중인 웨이팅이 있는지 체크 
  - 웨이팅 생성 컨트롤러 테스트 추가

### 📝 작업 요약

- 웨이팅 알림 구현
- redis 대기열 로직 수정

### **☑️** 중점적으로 리뷰 할 부분

- MemberWaitingService 내 `sendMessageToThirdRankMember()`, `sendMessageToMember()` 함수
- `OwnerWaitingService`에서 `MemberWaitingService`를 참조해서 메세지 함수 호출해도 되는지
- RedisWaitingLineRepository 로직
- 알림 메세지 내용
