### PR TITLE
feat : Owner logout 기능 구현

### DIFF
--- a/src/main/java/com/prgrms/catchtable/jwt/service/RefreshTokenService.java
+++ b/src/main/java/com/prgrms/catchtable/jwt/service/RefreshTokenService.java
@@ -40,4 +40,9 @@ public class RefreshTokenService {
         return refreshTokenRepository.findRefreshTokenByToken(refreshToken)
             .orElseThrow(() -> new NotFoundCustomException(NOT_FOUND_REFRESH_TOKEN));
     }
+
+    @Transactional
+    public void deleteRefreshToken(String email){
+        refreshTokenRepository.deleteRefreshTokenByEmail(email);
+    }
 }

--- a/src/main/java/com/prgrms/catchtable/owner/controller/OwnerController.java
+++ b/src/main/java/com/prgrms/catchtable/owner/controller/OwnerController.java
@@ -1,6 +1,8 @@
 package com.prgrms.catchtable.owner.controller;
 
+import com.prgrms.catchtable.common.login.LogIn;
 import com.prgrms.catchtable.jwt.token.Token;
+import com.prgrms.catchtable.owner.domain.Owner;
 import com.prgrms.catchtable.owner.dto.request.JoinOwnerRequest;
 import com.prgrms.catchtable.owner.dto.request.LoginOwnerRequest;
 import com.prgrms.catchtable.owner.dto.response.JoinOwnerResponse;
@@ -34,6 +36,12 @@ public class OwnerController {
         Token responseToken = ownerService.loginOwner(loginOwnerRequest);
 
         return ResponseEntity.ok(responseToken);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<String> logout(@LogIn Owner owner){
+        ownerService.logout(owner.getEmail());
+        return ResponseEntity.ok("logout");
     }
 
 }

--- a/src/main/java/com/prgrms/catchtable/owner/service/OwnerService.java
+++ b/src/main/java/com/prgrms/catchtable/owner/service/OwnerService.java
@@ -65,6 +65,11 @@ public class OwnerService {
         return createTotalToken(loginOwner.getEmail());
     }
 
+    @Transactional
+    public void logout(String email){
+        refreshTokenService.deleteRefreshToken(email);
+    }
+
     private void validatePassword(LoginOwnerRequest loginRequest, Owner loginOwner) {
         if (!passwordEncoder.matches(loginRequest.password(), loginOwner.getPassword())) {
             throw new BadRequestCustomException(INVALID_EMAIL_OR_PASSWORD);

--- a/src/test/java/com/prgrms/catchtable/owner/service/OwnerServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/owner/service/OwnerServiceTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.prgrms.catchtable.common.Role;
@@ -89,6 +91,17 @@ class OwnerServiceTest {
 
         //then
         assertThat(ownerService.loginOwner(loginOwnerRequest)).isEqualTo(token);
+    }
+
+    @Test
+    @DisplayName("로그아웃이 성공하면, RefreshToken을 삭제한다.")
+    void logoutSuccess() {
+        //when
+        ownerService.logout(email);
+
+        //then
+        verify(refreshTokenService, times(1)).deleteRefreshToken(any());
+
     }
 
     @Test


### PR DESCRIPTION
- closed #110 

### ⛏ 작업 상세 내용

- 로그아웃 API 
- RefreshToken 삭제
- 완료 후, 클라이언트에게 logout 메시지 전달

### 📝 작업 요약

- 

### **☑️** 중점적으로 리뷰 할 부분

-
