### PR TITLE
feat : Member login & logout 기능 구현

### DIFF
--- a/src/main/java/com/prgrms/catchtable/member/controller/MemberController.java
+++ b/src/main/java/com/prgrms/catchtable/member/controller/MemberController.java
@@ -1,0 +1,36 @@
+package com.prgrms.catchtable.member.controller;
+
+import com.prgrms.catchtable.common.login.LogIn;
+import com.prgrms.catchtable.member.domain.Member;
+import com.prgrms.catchtable.member.service.MemberService;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/login/kakao")
+    public ResponseEntity<?> loginRedirect(){
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setLocation(URI.create("/oauth2/authorization/kakao"));
+        return new ResponseEntity<>(httpHeaders, HttpStatus.MOVED_PERMANENTLY);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<String> logout(@LogIn Member member){
+        memberService.logout(member.getEmail());
+        return ResponseEntity.ok("logout");
+    }
+
+}

--- a/src/main/java/com/prgrms/catchtable/member/service/MemberService.java
+++ b/src/main/java/com/prgrms/catchtable/member/service/MemberService.java
@@ -34,6 +34,11 @@ public class MemberService {
         return createTotalToken(email);
     }
 
+    @Transactional
+    public void logout(String email){
+        refreshTokenService.deleteRefreshToken(email);
+    }
+
     private Token createTotalToken(String email) {
         Token totalToken = jwtTokenProvider.createToken(email, Role.MEMBER);
         refreshTokenService.saveRefreshToken(totalToken);


### PR DESCRIPTION
- closed #106 

### ⛏ 작업 상세 내용

- Member 로그인 API (리다이렉션)
- Member 로그아웃 API
- RefreshToken 삭제
- 로그아웃 완료 후, 클라이언트에게 logout 메시지 전달

### 📝 작업 요약

- 

### **☑️** 중점적으로 리뷰 할 부분

-
