### PR TITLE
feat : 예약 dto mapper 수정

### DIFF
--- a/src/docs/asciidoc/api/waiting/waiting.adoc
+++ b/src/docs/asciidoc/api/waiting/waiting.adoc
@@ -55,7 +55,6 @@ include::{snippets}/member-waiting-controller-docs-test/cancel-waiting/http-requ
 include::{snippets}/member-waiting-controller-docs-test/cancel-waiting/http-response.adoc[]
 include::{snippets}/member-waiting-controller-docs-test/cancel-waiting/response-fields.adoc[]
 
-
 === 웨이팅 입장 API
 
 ==== HTTP Request

--- a/src/main/java/com/prgrms/catchtable/jwt/service/RefreshTokenService.java
+++ b/src/main/java/com/prgrms/catchtable/jwt/service/RefreshTokenService.java
@@ -42,7 +42,7 @@ public class RefreshTokenService {
     }
 
     @Transactional
-    public void deleteRefreshToken(String email){
+    public void deleteRefreshToken(String email) {
         refreshTokenRepository.deleteRefreshTokenByEmail(email);
     }
 }

--- a/src/main/java/com/prgrms/catchtable/member/controller/MemberController.java
+++ b/src/main/java/com/prgrms/catchtable/member/controller/MemberController.java
@@ -21,14 +21,14 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping("/login/kakao")
-    public ResponseEntity<?> loginRedirect(){
+    public ResponseEntity<?> loginRedirect() {
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.setLocation(URI.create("/oauth2/authorization/kakao"));
         return new ResponseEntity<>(httpHeaders, HttpStatus.MOVED_PERMANENTLY);
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<String> logout(@LogIn Member member){
+    public ResponseEntity<String> logout(@LogIn Member member) {
         memberService.logout(member.getEmail());
         return ResponseEntity.ok("logout");
     }

--- a/src/main/java/com/prgrms/catchtable/member/service/MemberService.java
+++ b/src/main/java/com/prgrms/catchtable/member/service/MemberService.java
@@ -35,7 +35,7 @@ public class MemberService {
     }
 
     @Transactional
-    public void logout(String email){
+    public void logout(String email) {
         refreshTokenService.deleteRefreshToken(email);
     }
 

--- a/src/main/java/com/prgrms/catchtable/owner/controller/OwnerController.java
+++ b/src/main/java/com/prgrms/catchtable/owner/controller/OwnerController.java
@@ -39,7 +39,7 @@ public class OwnerController {
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<String> logout(@LogIn Owner owner){
+    public ResponseEntity<String> logout(@LogIn Owner owner) {
         ownerService.logout(owner.getEmail());
         return ResponseEntity.ok("logout");
     }

--- a/src/main/java/com/prgrms/catchtable/owner/service/OwnerService.java
+++ b/src/main/java/com/prgrms/catchtable/owner/service/OwnerService.java
@@ -66,7 +66,7 @@ public class OwnerService {
     }
 
     @Transactional
-    public void logout(String email){
+    public void logout(String email) {
         refreshTokenService.deleteRefreshToken(email);
     }
 

--- a/src/main/java/com/prgrms/catchtable/reservation/dto/mapper/ReservationMapper.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/dto/mapper/ReservationMapper.java
@@ -16,7 +16,7 @@ public class ReservationMapper {
     public static CreateReservationResponse toCreateReservationResponse(Reservation reservation) {
         return CreateReservationResponse.builder()
             .shopName(reservation.getShop().getName())
-            .memberName("memberA")
+            .memberName(reservation.getMember().getName())
             .date(reservation.getReservationTime().getTime())
             .peopleCount(reservation.getPeopleCount())
             .build();
@@ -35,7 +35,7 @@ public class ReservationMapper {
     public static ModifyReservationResponse toModifyReservationResponse(Reservation reservation) {
         return ModifyReservationResponse.builder()
             .shopName(reservation.getShop().getName())
-            .memberName("memberA")
+            .memberName(reservation.getMember().getName())
             .date(reservation.getReservationTime().getTime())
             .peopleCount(reservation.getPeopleCount())
             .build();

--- a/src/main/java/com/prgrms/catchtable/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/prgrms/catchtable/reservation/repository/ReservationRepository.java
@@ -18,6 +18,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     List<Reservation> findAllWithReservationTimeAndShopByMemberId(@Param("member") Member member);
 
     @Query("select r from Reservation r "
+        + "join fetch r.member m "
         + "join fetch r.reservationTime rt "
         + "join fetch rt.shop "
         + "where r.id = :reservationId")

--- a/src/main/java/com/prgrms/catchtable/shop/domain/Shop.java
+++ b/src/main/java/com/prgrms/catchtable/shop/domain/Shop.java
@@ -70,7 +70,7 @@ public class Shop extends BaseEntity {
     public int findWaitingNumber() {
         return ++waitingCount;
     }
-  
+
     public void updateMenuList(List<Menu> menuList) {
         this.menuList.addAll(menuList);
         this.menuList.forEach(menu -> menu.insertShop(this));

--- a/src/test/java/com/prgrms/catchtable/reservation/controller/MemberReservationControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/controller/MemberReservationControllerTest.java
@@ -172,7 +172,8 @@ class MemberReservationControllerTest extends BaseIntegrationTest {
         ReservationTime reservationTime = reservationTimeRepository.findAll().get(0);
         Member member1 = memberRepository.findAll().get(0);
         reservationTime.setOccupiedTrue();
-        Reservation reservation = ReservationFixture.getReservationWithMember(reservationTime, member1);
+        Reservation reservation = ReservationFixture.getReservationWithMember(reservationTime,
+            member1);
         Reservation savedReservation = reservationRepository.save(reservation);
         /**
          * 수정하려는 예약시간 예제 데이터 생성
@@ -206,7 +207,8 @@ class MemberReservationControllerTest extends BaseIntegrationTest {
     void cancelReservation() throws Exception {
         ReservationTime reservationTime = reservationTimeRepository.findAll().get(0);
         Member member1 = memberRepository.findAll().get(0);
-        Reservation reservation = ReservationFixture.getReservationWithMember(reservationTime, member1);
+        Reservation reservation = ReservationFixture.getReservationWithMember(reservationTime,
+            member1);
         Reservation savedReservation = reservationRepository.save(reservation);
 
         mockMvc.perform(delete("/reservations/{reservationId}", savedReservation.getId())

--- a/src/test/java/com/prgrms/catchtable/reservation/controller/MemberReservationControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/controller/MemberReservationControllerTest.java
@@ -170,8 +170,9 @@ class MemberReservationControllerTest extends BaseIntegrationTest {
     @DisplayName("예약 수정 api 호출에 성공한다.")
     void modifyReservation() throws Exception {
         ReservationTime reservationTime = reservationTimeRepository.findAll().get(0);
+        Member member1 = memberRepository.findAll().get(0);
         reservationTime.setOccupiedTrue();
-        Reservation reservation = ReservationFixture.getReservation(reservationTime);
+        Reservation reservation = ReservationFixture.getReservationWithMember(reservationTime, member1);
         Reservation savedReservation = reservationRepository.save(reservation);
         /**
          * 수정하려는 예약시간 예제 데이터 생성
@@ -204,7 +205,8 @@ class MemberReservationControllerTest extends BaseIntegrationTest {
     @DisplayName("예약 삭제 api 호출에 성공한다")
     void cancelReservation() throws Exception {
         ReservationTime reservationTime = reservationTimeRepository.findAll().get(0);
-        Reservation reservation = ReservationFixture.getReservation(reservationTime);
+        Member member1 = memberRepository.findAll().get(0);
+        Reservation reservation = ReservationFixture.getReservationWithMember(reservationTime, member1);
         Reservation savedReservation = reservationRepository.save(reservation);
 
         mockMvc.perform(delete("/reservations/{reservationId}", savedReservation.getId())

--- a/src/test/java/com/prgrms/catchtable/reservation/controller/OwnerReservationControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/controller/OwnerReservationControllerTest.java
@@ -12,6 +12,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.prgrms.catchtable.common.base.BaseIntegrationTest;
 import com.prgrms.catchtable.common.data.shop.ShopData;
 import com.prgrms.catchtable.jwt.token.Token;
+import com.prgrms.catchtable.member.MemberFixture;
+import com.prgrms.catchtable.member.domain.Member;
+import com.prgrms.catchtable.member.repository.MemberRepository;
 import com.prgrms.catchtable.owner.domain.Owner;
 import com.prgrms.catchtable.owner.fixture.OwnerFixture;
 import com.prgrms.catchtable.owner.repository.OwnerRepository;
@@ -44,6 +47,8 @@ class OwnerReservationControllerTest extends BaseIntegrationTest {
     private ShopRepository shopRepository;
     @Autowired
     private ReservationRepository reservationRepository;
+    @Autowired
+    private MemberRepository memberRepository;
 
     @BeforeEach
     void setUp() {
@@ -53,8 +58,11 @@ class OwnerReservationControllerTest extends BaseIntegrationTest {
         ReservationTime savedReservationTime = reservationTimeRepository.save(reservationTime);
         savedReservationTime.setOccupiedTrue();
         log.info("예약 시간 차지 여부 : {}", savedReservationTime.isOccupied());
+
+        Member member = MemberFixture.member("qwe@naver.com");
+        Member savedMember = memberRepository.save(member);
         Reservation reservation = reservationRepository.save(
-            ReservationFixture.getReservation(savedReservationTime));
+            ReservationFixture.getReservationWithMember(savedReservationTime,savedMember));
 
         ReservationTime reservationTime2 = ReservationFixture.getAnotherReservationTimeNotPreOccupied();
         reservationTime2.insertShop(shop);

--- a/src/test/java/com/prgrms/catchtable/reservation/controller/OwnerReservationControllerTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/controller/OwnerReservationControllerTest.java
@@ -62,7 +62,7 @@ class OwnerReservationControllerTest extends BaseIntegrationTest {
         Member member = MemberFixture.member("qwe@naver.com");
         Member savedMember = memberRepository.save(member);
         Reservation reservation = reservationRepository.save(
-            ReservationFixture.getReservationWithMember(savedReservationTime,savedMember));
+            ReservationFixture.getReservationWithMember(savedReservationTime, savedMember));
 
         ReservationTime reservationTime2 = ReservationFixture.getAnotherReservationTimeNotPreOccupied();
         reservationTime2.insertShop(shop);

--- a/src/test/java/com/prgrms/catchtable/reservation/fixture/ReservationFixture.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/fixture/ReservationFixture.java
@@ -3,6 +3,7 @@ package com.prgrms.catchtable.reservation.fixture;
 import static com.prgrms.catchtable.reservation.domain.ReservationStatus.COMPLETED;
 
 import com.prgrms.catchtable.common.data.shop.ShopData;
+import com.prgrms.catchtable.member.MemberFixture;
 import com.prgrms.catchtable.member.domain.Member;
 import com.prgrms.catchtable.reservation.domain.Reservation;
 import com.prgrms.catchtable.reservation.domain.ReservationStatus;
@@ -108,4 +109,15 @@ public class ReservationFixture {
             .build();
     }
 
+    public static Reservation getReservationWithMember(ReservationTime reservationTime, Member member) {
+        if (!reservationTime.isOccupied()) {
+            reservationTime.setOccupiedTrue();
+        }
+        return Reservation.builder()
+            .status(COMPLETED)
+            .peopleCount(4)
+            .reservationTime(reservationTime)
+            .member(member)
+            .build();
+    }
 }

--- a/src/test/java/com/prgrms/catchtable/reservation/fixture/ReservationFixture.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/fixture/ReservationFixture.java
@@ -3,7 +3,6 @@ package com.prgrms.catchtable.reservation.fixture;
 import static com.prgrms.catchtable.reservation.domain.ReservationStatus.COMPLETED;
 
 import com.prgrms.catchtable.common.data.shop.ShopData;
-import com.prgrms.catchtable.member.MemberFixture;
 import com.prgrms.catchtable.member.domain.Member;
 import com.prgrms.catchtable.reservation.domain.Reservation;
 import com.prgrms.catchtable.reservation.domain.ReservationStatus;
@@ -109,7 +108,8 @@ public class ReservationFixture {
             .build();
     }
 
-    public static Reservation getReservationWithMember(ReservationTime reservationTime, Member member) {
+    public static Reservation getReservationWithMember(ReservationTime reservationTime,
+        Member member) {
         if (!reservationTime.isOccupied()) {
             reservationTime.setOccupiedTrue();
         }

--- a/src/test/java/com/prgrms/catchtable/reservation/repository/ReservationRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/repository/ReservationRepositoryTest.java
@@ -70,7 +70,10 @@ class ReservationRepositoryTest {
         reservationTime.insertShop(savedShop);
         ReservationTime savedReservationTime = reservationTimeRepository.save(reservationTime);
 
-        Reservation reservation = ReservationFixture.getReservation(savedReservationTime);
+        Member member = MemberFixture.member("dlswns661035@gmail.com");
+        Member savedMember = memberRepository.save(member);
+
+        Reservation reservation = ReservationFixture.getReservationWithMember(savedReservationTime, savedMember);
         Reservation savedReservation = reservationRepository.save(reservation);
 
         Reservation findReservation = reservationRepository.findByIdWithReservationTimeAndShop(

--- a/src/test/java/com/prgrms/catchtable/reservation/repository/ReservationRepositoryTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/repository/ReservationRepositoryTest.java
@@ -73,7 +73,8 @@ class ReservationRepositoryTest {
         Member member = MemberFixture.member("dlswns661035@gmail.com");
         Member savedMember = memberRepository.save(member);
 
-        Reservation reservation = ReservationFixture.getReservationWithMember(savedReservationTime, savedMember);
+        Reservation reservation = ReservationFixture.getReservationWithMember(savedReservationTime,
+            savedMember);
         Reservation savedReservation = reservationRepository.save(reservation);
 
         Reservation findReservation = reservationRepository.findByIdWithReservationTimeAndShop(

--- a/src/test/java/com/prgrms/catchtable/reservation/service/MemberReservationServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/service/MemberReservationServiceTest.java
@@ -204,7 +204,7 @@ class MemberReservationServiceTest {
         ReservationTime modifyTime = ReservationFixture.getAnotherReservationTimeNotPreOccupied();
         ReflectionTestUtils.setField(modifyTime, "id", 2L); //수정하려는 예약시간 객체 -> Id : 2
 
-        Reservation reservation = ReservationFixture.getReservation(reservationTime);
+        Reservation reservation = ReservationFixture.getReservationWithMember(reservationTime, MemberFixture.member("dlsw@gamil.com"));
         ModifyReservationRequest request = ReservationFixture.getModifyReservationRequest(
             2L);
 

--- a/src/test/java/com/prgrms/catchtable/reservation/service/MemberReservationServiceTest.java
+++ b/src/test/java/com/prgrms/catchtable/reservation/service/MemberReservationServiceTest.java
@@ -204,7 +204,8 @@ class MemberReservationServiceTest {
         ReservationTime modifyTime = ReservationFixture.getAnotherReservationTimeNotPreOccupied();
         ReflectionTestUtils.setField(modifyTime, "id", 2L); //수정하려는 예약시간 객체 -> Id : 2
 
-        Reservation reservation = ReservationFixture.getReservationWithMember(reservationTime, MemberFixture.member("dlsw@gamil.com"));
+        Reservation reservation = ReservationFixture.getReservationWithMember(reservationTime,
+            MemberFixture.member("dlsw@gamil.com"));
         ModifyReservationRequest request = ReservationFixture.getModifyReservationRequest(
             2L);
 


### PR DESCRIPTION
### ⛏ 작업 상세 내용
- close #113 

- 전에 mapper에서 응답 dto로 변환할 때 회원이름에 예시데이터인 "memberA"로 설정되어 있어 예약한 회원의 이름을 넣어주는 것으로 변경
- 예약 가져오는 쿼리에 회원도 페치조인 추가
- 이에 따른 테스트 코드 전부 수정

### 📝 작업 요약

- mapper 및 쿼리 수정

### **☑️** 중점적으로 리뷰 할 부분

- 테스트 코드는 안 보셔도 됩니다. 수정한 부분에 대해서만 테스트 코드 수정해서 mapper랑 쿼리만 리뷰 부탁~
